### PR TITLE
Io hooks

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -125,7 +125,7 @@ module VCR
     end
 
     def raw_yaml_content
-      content = File.read(file)
+      content = after_read(File.read(file))
       return content unless @erb
 
       template = ERB.new(content)
@@ -170,8 +170,19 @@ module VCR
       if VCR::Config.cassette_library_dir && new_recorded_interactions.size > 0
         directory = File.dirname(file)
         FileUtils.mkdir_p directory unless File.exist?(directory)
-        File.open(file, 'w') { |f| f.write merged_interactions.to_yaml }
+        File.open(file, 'w') { |f| f.write before_write(merged_interactions.to_yaml) }
       end
+    end
+    
+    def before_write(recordings)
+      hook = VCR::Config.before_write_hook      
+      hook ? hook[recordings] : recordings
+    end
+    
+    def after_read(recordings)
+      hook = VCR::Config.after_read_hook      
+      content = hook ? hook[recordings] : recordings
+      content
     end
   end
 end

--- a/lib/vcr/config.rb
+++ b/lib/vcr/config.rb
@@ -41,6 +41,21 @@ module VCR
       def allow_http_connections_when_no_cassette?
         !!@allow_http_connections_when_no_cassette
       end
+      
+      attr_reader :before_write_hook
+      def before_write(&block)
+        @before_write_hook = block
+      end
+      
+      attr_reader :after_read_hook
+      def after_read(&block)
+        @after_read_hook = block
+      end      
+      
+      def clear_hooks
+        @before_write_hook = nil
+        @after_read_hook = nil
+      end
     end
   end
 end


### PR DESCRIPTION
Added before_write and after_read hooks. Allows you to do

```
VCR.config do |c|
    c.before_write do |recordings|
        recordings.gsub(ENV['GITHUB_TOKEN'], "__github_token__")
    end
    c.after_read do |recordings|
        recordings.gsub("__github_token__", ENV['GITHUB_TOKEN'])
    end
end
```

I've included specs for both hooks, you'll find them in cassette_spec.rb.

I took it for a spin on a project I'm working on and it seems to work great. If you're happy with it and want to merge it in, let me know and I'll update the config wiki.
