### PR TITLE
Vcr hooks

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -101,7 +101,7 @@ module VCR
       if file && File.size?(file)
         begin
           interactions = YAML.load(raw_yaml_content)
-
+          before_playback(interactions)
           if VCR.http_stubbing_adapter.ignore_localhost?
             interactions.reject! do |i|
               i.uri.is_a?(String) && VCR::LOCALHOST_ALIASES.include?(URI.parse(i.uri).host)
@@ -170,8 +170,19 @@ module VCR
       if VCR::Config.cassette_library_dir && new_recorded_interactions.size > 0
         directory = File.dirname(file)
         FileUtils.mkdir_p directory unless File.exist?(directory)
+        before_record(merged_interactions)
         File.open(file, 'w') { |f| f.write merged_interactions.to_yaml }
       end
+    end
+    
+    def before_record(interactions)
+      hook = VCR::Config.before_record_hook
+      interactions.each{ |interaction| hook[interaction] } if hook
+    end
+    
+    def before_playback(interactions)
+      hook = VCR::Config.before_playback_hook
+      interactions.each{ |interaction| hook[interaction] } if hook
     end
   end
 end

--- a/lib/vcr/config.rb
+++ b/lib/vcr/config.rb
@@ -41,6 +41,21 @@ module VCR
       def allow_http_connections_when_no_cassette?
         !!@allow_http_connections_when_no_cassette
       end
+      
+      attr_reader :before_record_hook
+      def before_record(&block)
+        @before_record_hook = block
+      end
+      
+      attr_reader :before_playback_hook
+      def before_playback(&block)
+        @before_playback_hook = block
+      end      
+      
+      def clear_hooks
+        @before_record_hook = nil
+        @before_playback_hook = nil
+      end
     end
   end
 end

--- a/spec/cassette_spec.rb
+++ b/spec/cassette_spec.rb
@@ -225,6 +225,40 @@ describe VCR::Cassette do
           i3.request.uri.should == 'http://example.com:80/'
           i3.response.body.should =~ /Another example\.com response/
         end
+        
+        context "with before_playback hook defined" do
+          before do
+            VCR.config do |c|
+              c.before_playback do |interaction|
+                substitutions =  {
+                    "typing" => "singing",
+                    "this server" => "this mountain",
+                    "Another" => "Yet another"
+                }
+                substitutions.each do |before, after|
+                  interaction.response.body.gsub!(before, after)
+                end
+              end
+            end
+          end
+          
+          after do
+            VCR::Config.clear_hooks
+          end
+          
+          it "loads the recorded interactions from the library yml file" do
+            VCR::Config.cassette_library_dir = File.expand_path(File.dirname(__FILE__) + "/fixtures/#{YAML_SERIALIZATION_VERSION}/cassette_spec")
+            cassette = VCR::Cassette.new('example', :record => record_mode)
+
+            cassette.should have(3).recorded_interactions
+
+            i1, i2, i3 = *cassette.recorded_interactions
+
+            i1.response.body.should =~ /You have reached this web page by singing.+example\.com/
+            i2.response.body.should =~ /foo was not found on this mountain/
+            i3.response.body.should =~ /Yet another example\.com response/
+          end          
+        end
 
         if stub_requests
           it "stubs the recorded requests with the http stubbing adapter" do
@@ -275,7 +309,35 @@ describe VCR::Cassette do
       saved_recorded_interactions = File.open(cassette.file, "r") { |f| YAML.load(f.read) }
       saved_recorded_interactions.should == recorded_interactions
     end
+    
+    context "with before_record hook defined" do
+      before do
+        VCR.config do |c|
+          c.before_record do |interaction|
+            interaction.response.gsub!("response_1", "different_response")
+          end
+        end
+      end
+      
+      after do
+        VCR::Config.clear_hooks
+      end
+      
+      it "should update interactions before they're recorded" do
+        recorded_interactions = [
+          VCR::HTTPInteraction.new('req_sig_1', 'response_1')
+        ]
 
+        cassette = VCR::Cassette.new(:before_hook_test)
+        cassette.stub!(:new_recorded_interactions).and_return(recorded_interactions)
+        
+        cassette.eject
+        saved_content = File.open(cassette.file, "r") { |f| f.read }
+        saved_content.should_not include('response_1')
+        saved_content.should include('different_response')
+      end
+    end
+    
     it "writes the recorded interactions to a subdirectory if the cassette name includes a directory" do
       recorded_interactions = [VCR::HTTPInteraction.new(:the_request, :the_response)]
       cassette = VCR::Cassette.new('subdirectory/test_cassette')


### PR DESCRIPTION
I've switched to using the before_record and before_playback hooks e.g.

```
VCR.config do |c|
  c.before_record do |interaction|
    interaction.request.uri.gsub!(ENV['SECRET'], "__gh_access_key__")
  end
  c.before_playback do |interaction|
    interaction.request.uri.gsub!("__gh_access_key__", ENV['SECRET'])
  end
end
```

I've updated the specs but haven't done the cucumber features. Wasn't really sure to start with those so if you think you can do them quickly I'd go ahead. Otherwise I'll have a closer look and send another pull request when they're done.
