### PR TITLE
Log all requests configuration option

### DIFF
--- a/features/configuration/log_all_to.feature
+++ b/features/configuration/log_all_to.feature
@@ -1,0 +1,44 @@
+Feature: Allow all HTTP connections to be logged by default
+
+  Scenario Outline: Cassettes record and replay as normal
+    Given a file named "vcr_setup.rb" with:
+      """
+      require 'vcr_cucumber_helpers'
+
+      if ARGV.include?('--with-server')
+        start_sinatra_app(:port => 7777) do
+          get('/') { "Hello" }
+        end
+      end
+
+      require 'vcr'
+
+      VCR.config do |c|
+        c.log_all_to = "application"
+        c.stub_with <stub_with>
+        c.cassette_library_dir = 'cassettes'
+      end
+      """
+    And a file named "record_replay_cassette.rb" with:
+      """
+      require 'vcr_setup.rb'
+      include_http_adapter_for("<http_lib>")
+
+      puts "Response: " + response_body_for(:get, "http://localhost:7777/")
+      """
+    When I run "ruby record_replay_cassette.rb --with-server"
+    Then the output should contain "Response: Hello"
+    And the file "cassettes/application.yml" should contain "body: Hello"
+
+    When I run "ruby record_replay_cassette.rb"
+    Then the output should contain "Response: Hello"
+    
+    Examples:
+      | stub_with  | http_lib        |
+      # | :fakeweb   | net/http        |
+      # | :webmock   | net/http        |
+      # | :webmock   | httpclient      |
+      # | :webmock   | patron          |
+      # | :webmock   | curb            |
+      # | :webmock   | em-http-request |
+      | :typhoeus  | typhoeus        |

--- a/lib/vcr/config.rb
+++ b/lib/vcr/config.rb
@@ -27,6 +27,11 @@ module VCR
     def stub_with(*http_stubbing_libraries)
       @http_stubbing_libraries = http_stubbing_libraries
     end
+    
+    attr_reader :log_all_to
+    def log_all_to=(cassette_name)
+      @log_all_to = cassette_name
+    end
 
     def http_stubbing_libraries
       @http_stubbing_libraries ||= []

--- a/lib/vcr/http_stubbing_adapters/typhoeus.rb
+++ b/lib/vcr/http_stubbing_adapters/typhoeus.rb
@@ -93,5 +93,21 @@ Typhoeus::Hydra.after_request_before_on_complete do |request|
   end
 end
 
+module Typhoeus
+  class Request
+    class << self
+      def run_with_cassette(url, params)
+        use_cassette = VCR::Config.log_all_to && !VCR::Config.log_all_to.empty?
+        VCR.insert_cassette(VCR::Config.log_all_to) if use_cassette
+        return_value = run_without_cassette(url, params)
+        VCR.eject_cassette if use_cassette
+        return_value
+      end
+      alias_method :run_without_cassette, :run
+      alias_method :run, :run_with_cassette
+    end
+  end 
+end
+
 VCR::HttpStubbingAdapters::Common.add_vcr_info_to_exception_message(Typhoeus::Hydra::NetConnectNotAllowedError)
 

--- a/spec/vcr/config_spec.rb
+++ b/spec/vcr/config_spec.rb
@@ -45,6 +45,13 @@ describe VCR::Config do
       VCR::Config.http_stubbing_libraries.should == [:fakeweb, :typhoeus]
     end
   end
+  
+  describe '.log_all_to=' do
+    it 'stores the given name in log_all_to' do
+      VCR::Config.log_all_to = "application"
+      VCR::Config.log_all_to.should == "application"
+    end
+  end
 
   describe '.http_stubbing_libraries' do
     it 'returns an empty array even when the variable is nil' do


### PR DESCRIPTION
Hey,

In our application we wanted to be able to record all requests by default without having to wrap each call in a VCR block.

This pull request contains a couple of tests and the code implementation for Typhoeus as this is what we are using on the project.

Let me know what you think about this feature and I can extend it to the other mocking libraries if you think it's a good idea.

Scott.
