### PR TITLE
Return recorded responses with the same encoding

### DIFF
--- a/lib/vcr/http_stubbing_adapters/excon.rb
+++ b/lib/vcr/http_stubbing_adapters/excon.rb
@@ -184,6 +184,7 @@ module VCR
               VCR::ResponseStatus.new(response.status, nil),
               response.headers,
               response.body,
+              response.body.encoding.to_s,
               nil
           end
 

--- a/lib/vcr/http_stubbing_adapters/typhoeus.rb
+++ b/lib/vcr/http_stubbing_adapters/typhoeus.rb
@@ -95,6 +95,7 @@ Typhoeus::Hydra.after_request_before_on_complete do |request|
         ),
         request.response.headers_hash,
         request.response.body,
+        request.response.body.encoding.to_s,
         request.response.http_version
       )
     )

--- a/lib/vcr/http_stubbing_adapters/webmock.rb
+++ b/lib/vcr/http_stubbing_adapters/webmock.rb
@@ -98,6 +98,7 @@ WebMock.after_request(:real_requests_only => true) do |request, response|
         ),
         response.headers,
         response.body,
+        response.body.encoding.to_s,
         '1.1'
       )
     )

--- a/lib/vcr/middleware/faraday.rb
+++ b/lib/vcr/middleware/faraday.rb
@@ -60,6 +60,7 @@ module VCR
             VCR::ResponseStatus.new(response.status, nil),
             response.headers,
             response.body,
+            response.body.encoding.to_s,
             '1.1'
           )
         end

--- a/lib/vcr/structs/response.rb
+++ b/lib/vcr/structs/response.rb
@@ -1,5 +1,5 @@
 module VCR
-  class Response < Struct.new(:status, :headers, :body, :http_version)
+  class Response < Struct.new(:status, :headers, :body, :body_encoding, :http_version)
     include Normalizers::Header
     include Normalizers::Body
 
@@ -8,8 +8,16 @@ module VCR
         ResponseStatus.from_net_http_response(response),
         response.to_hash,
         response.body,
-        response.http_version
+        response.body.encoding.to_s,
+        response.http_version,
       )
+    end
+
+    def body
+      if body_encoding and self[:body]
+        self[:body].force_encoding body_encoding
+      end
+      self[:body]
     end
 
     def update_content_length_header

--- a/spec/fixtures/1.9.1/cassette_spec/example.yml
+++ b/spec/fixtures/1.9.1/cassette_spec/example.yml
@@ -43,6 +43,7 @@
       </BODY>
       </HTML>
 
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -76,6 +77,7 @@
       <address>Apache/2.2.3 (CentOS) Server at example.com Port 80</address>
       </body></html>
 
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -107,4 +109,5 @@
       content-length: 
       - "438"
     :body: Another example.com response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"

--- a/spec/fixtures/1.9.1/cassette_spec/with_localhost_requests.yml
+++ b/spec/fixtures/1.9.1/cassette_spec/with_localhost_requests.yml
@@ -29,6 +29,7 @@
       accept-ranges: 
       - bytes
     :body: Localhost response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -52,6 +53,7 @@
       content-length: 
       - "277"
     :body: 127.0.0.1 response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -75,6 +77,7 @@
       content-length: 
       - "277"
     :body: 127.0.0.1 response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -106,4 +109,5 @@
       accept-ranges: 
       - bytes
     :body: example.com response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"

--- a/spec/fixtures/1.9.1/fake_example.com_responses.yml
+++ b/spec/fixtures/1.9.1/fake_example.com_responses.yml
@@ -29,6 +29,7 @@
       accept-ranges: 
       - bytes
     :body: example.com get response 1 with path=foo
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -60,6 +61,7 @@
       accept-ranges: 
       - bytes
     :body: example.com get response 2 with path=foo
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -89,6 +91,7 @@
       accept-ranges: 
       - bytes
     :body: example.com post response with id=3
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -105,4 +108,5 @@
       - bar=bazz
       - foo=bar
     :body: this response has two set-cookie headers
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"

--- a/spec/fixtures/1.9.1/match_requests_on.yml
+++ b/spec/fixtures/1.9.1/match_requests_on.yml
@@ -13,6 +13,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: post method response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -28,6 +29,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: get method response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -43,6 +45,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: example1.com host response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -58,12 +61,14 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: example2.com host response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
     :method: :post
     :uri: http://example.com:80/path1
     :body: 
+    :body_encoding: ASCII-8BIT
     :headers: 
   :response: !ruby/struct:VCR::Response 
     :status: !ruby/struct:VCR::ResponseStatus 
@@ -73,6 +78,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: path1 response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -88,6 +94,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: path2 response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -103,6 +110,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: uri1 response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -118,6 +126,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: uri2 response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -133,6 +142,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: val1 body response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -148,6 +158,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: val2 body response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -165,6 +176,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: val1 header response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   :request: !ruby/struct:VCR::Request 
@@ -182,4 +194,5 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     :body: val2 header response
+    :body_encoding: ASCII-8BIT
     :http_version: "1.1"

--- a/spec/fixtures/not_1.9.1/0_3_1_cassette.yml
+++ b/spec/fixtures/not_1.9.1/0_3_1_cassette.yml
@@ -23,6 +23,7 @@
       - "438"
       accept-ranges: 
       - bytes
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
     message: OK
     read: true

--- a/spec/fixtures/not_1.9.1/cassette_spec/example.yml
+++ b/spec/fixtures/not_1.9.1/cassette_spec/example.yml
@@ -43,6 +43,7 @@
       </BODY>
       </HTML>
 
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -76,6 +77,7 @@
       <address>Apache/2.2.3 (CentOS) Server at example.com Port 80</address>
       </body></html>
 
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -107,4 +109,5 @@
       accept-ranges: 
       - bytes
     body: Another example.com response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"

--- a/spec/fixtures/not_1.9.1/cassette_spec/with_localhost_requests.yml
+++ b/spec/fixtures/not_1.9.1/cassette_spec/with_localhost_requests.yml
@@ -29,6 +29,7 @@
       accept-ranges: 
       - bytes
     body: Localhost response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -52,6 +53,7 @@
       content-length: 
       - "277"
     body: 127.0.0.1 response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -75,6 +77,7 @@
       content-length: 
       - "277"
     body: 127.0.0.1 response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -106,4 +109,5 @@
       accept-ranges: 
       - bytes
     body: example.com response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"

--- a/spec/fixtures/not_1.9.1/fake_example.com_responses.yml
+++ b/spec/fixtures/not_1.9.1/fake_example.com_responses.yml
@@ -29,6 +29,7 @@
       accept-ranges: 
       - bytes
     body: example.com get response 1 with path=foo
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -60,6 +61,7 @@
       accept-ranges: 
       - bytes
     body: example.com get response 2 with path=foo
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -89,6 +91,7 @@
       accept-ranges: 
       - bytes
     body: example.com post response with id=3
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -105,4 +108,5 @@
       - bar=bazz
       - foo=bar
     body: this respons has two set-cookie headers
+    body_encoding: ASCII-8BIT
     http_version: "1.1"

--- a/spec/fixtures/not_1.9.1/match_requests_on.yml
+++ b/spec/fixtures/not_1.9.1/match_requests_on.yml
@@ -13,6 +13,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: post method response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -28,6 +29,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: get method response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -43,6 +45,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: example1.com host response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -58,6 +61,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: example2.com host response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -73,6 +77,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: path1 response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -88,6 +93,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: path2 response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -103,6 +109,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: uri1 response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -118,6 +125,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: uri2 response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -133,6 +141,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: val1 body response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -148,6 +157,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: val2 body response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 
@@ -165,6 +175,7 @@
       etag: 
       - "\"24ec5-1b6-4059a80bfd280\""
     body: val1 header response
+    body_encoding: ASCII-8BIT
     http_version: "1.1"
 - !ruby/struct:VCR::HTTPInteraction 
   request: !ruby/struct:VCR::Request 

--- a/spec/support/shared_example_groups/http_library.rb
+++ b/spec/support/shared_example_groups/http_library.rb
@@ -69,7 +69,7 @@ shared_examples_for "an http library" do |library, supported_request_match_attri
 
       context "when the the stubbed request and response has no headers" do
         let(:request)  { VCR::Request.new(:get, 'http://example.com:80/') }
-        let(:response) { VCR::Response.new(status, nil, response_body, '1.1') }
+        let(:response) { VCR::Response.new(status, nil, response_body, response_body.encoding.to_s, '1.1') }
 
         it 'returns the response for a matching request' do
           get_body_string(make_http_request(:get, 'http://example.com/')).should == response_body
@@ -79,7 +79,7 @@ shared_examples_for "an http library" do |library, supported_request_match_attri
       def self.test_url(description, url)
         context "when a URL #{description} has been stubbed" do
           let(:request)     { VCR::Request.new(:get, url) }
-          let(:response)    { VCR::Response.new(status, nil, response_body, '1.1') }
+          let(:response)    { VCR::Response.new(status, nil, response_body, response_body.encoding.to_s, '1.1') }
 
           it 'returns the expected response for the same request' do
             get_body_string(make_http_request(:get, url)).should == response_body

--- a/spec/vcr/structs/http_interaction_spec.rb
+++ b/spec/vcr/structs/http_interaction_spec.rb
@@ -34,6 +34,7 @@ describe VCR::HTTPInteraction do
         response_status,
         headers.dup,
         body.dup,
+        body.dup.encoding.to_s,
         '1.1'
       )
     end

--- a/spec/vcr/structs/response_spec.rb
+++ b/spec/vcr/structs/response_spec.rb
@@ -33,7 +33,7 @@ describe VCR::Response do
 
   it_performs 'body normalization' do
     def instance(body)
-      described_class.new(:status, {}, body, '1.1')
+      described_class.new(:status, {}, body, body.encoding.to_s, '1.1')
     end
   end
 


### PR DESCRIPTION
Save the encoding of the original body in the casette so we can force
the encoding when playing it.
