### PR TITLE
[excon] more consistent return value from stubbed responses

### DIFF
--- a/lib/vcr/http_stubbing_adapters/excon.rb
+++ b/lib/vcr/http_stubbing_adapters/excon.rb
@@ -119,15 +119,15 @@ module VCR
           end
 
           def stubbed_response
-            unless defined?(@stubbed_response)
-              @stubbed_response = VCR::HttpStubbingAdapters::Excon.stubbed_response_for(vcr_request)
-
-              if @stubbed_response && @stubbed_response.headers
-                @stubbed_response.headers = normalized_headers(@stubbed_response.headers)
+            @stubbed_response ||= begin
+              if stubbed_response = VCR::HttpStubbingAdapters::Excon.stubbed_response_for(vcr_request)
+                {
+                  :body     => stubbed_response.body,
+                  :headers  => normalized_headers(stubbed_response.headers || {}),
+                  :status   => stubbed_response.status.code
+                }
               end
             end
-
-            @stubbed_response
           end
 
           def http_connections_allowed?


### PR DESCRIPTION
I updated this to better match my expectations and to fix a bug that a user was running into.  It seems to fix his bug, but unfortunately I didn't have much luck adding passing or failing tests (I was probably missing something somewhat obvious here, but gave up after an hour or two of continuing to miss it).  Let me know if I can help clear that up, but the key thing is that excon expects a hash, rather than a struct, back from the mock stuff.  This is even more true in the soon-to-be released version where the struct style was causing problems.

Anyway, hopefully this makes sense and the tests seem to pass (though they pass without the change as well).  Let me know if there is anything else I can clarify or clean up to help get this in.

Thanks!
wes
