### PR TITLE
Fixing the nil query string exception when using uri_without_param(s)

### DIFF
--- a/lib/vcr/request_matcher_registry.rb
+++ b/lib/vcr/request_matcher_registry.rb
@@ -13,6 +13,8 @@ module VCR
     class URIWithoutParamsMatcher < Struct.new(:params_to_ignore)
       def partial_uri_from(request)
         URI(request.uri).tap do |uri|
+          next unless uri.query # ignore uris without params, e.g. "http://example.com/"
+
           uri.query = uri.query.split('&').tap { |params|
             params.map! do |p|
               key, value = p.split('=')

--- a/spec/vcr/request_matcher_registry_spec.rb
+++ b/spec/vcr/request_matcher_registry_spec.rb
@@ -127,6 +127,13 @@ module VCR
             request_with(:uri => 'http://example.com/search?foo=124&baz=9&bar=q')
           ).should be_true
         end
+
+        it 'matches two requests with URIs that have no params' do
+          subject[subject.send(meth, :foo, :bar)].matches?(
+            request_with(:uri => 'http://example.com/search'),
+            request_with(:uri => 'http://example.com/search')
+          ).should be_true
+        end
       end
     end
 


### PR DESCRIPTION
- VCR::RequestMatcherRegistry::URIWithoutParamsMatcher#partial_uri_from
- incorrectly expects uri.query never to be nil. However, it is nil when
- there are no query params.

See this issue for more details: https://github.com/myronmarston/vcr/issues/99
