### PR TITLE
Add contributing link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ VCR has been tested on the following ruby interpreters:
 * Report issues on [GitHub Issues](http://github.com/myronmarston/vcr/issues).
 * Pull requests are very welcome! Please include spec and/or feature coverage for every patch,
   and create a topic branch for every separate change you make.
+* See the [Contributing](https://github.com/myronmarston/vcr/wiki/Contributing)
+  wiki page for instructions on running the specs and features.
 
 If you find VCR useful, please recommend me on [working with rails](http://workingwithrails.com/person/16590-myron-marston).
 


### PR DESCRIPTION
I ran into a couple of issues when trying to get the features passing for local development, specifically regarding Git submodules and installing `rb-fevents` gem. I updated the [Contributing](https://github.com/myronmarston/vcr/wiki/Contributing) wiki page to address this and think it would be useful to link to this from the Development section in the README.

I noticed the wiki is no longer used for the primary documentation, would Relish be for this documentation?

BTW, this pull request will be featured in RailsCasts episode #300 where I show how to submit a pull request.
