### PR TITLE
Make cassette migrator set recorded_with to current VCR version

### DIFF
--- a/lib/vcr/cassette/migrator.rb
+++ b/lib/vcr/cassette/migrator.rb
@@ -42,7 +42,7 @@ module VCR
 
         hash = {
           "http_interactions" => http_interactions,
-          "recorded_with"     => "VCR 1.11.3" # assume the last 1.x release
+          "recorded_with"     => "VCR #{VCR.version}"
         }
 
         def hash.each

--- a/spec/fixtures/cassette_spec/example.yml
+++ b/spec/fixtures/cassette_spec/example.yml
@@ -108,4 +108,4 @@ http_interactions:
     body: Another example.com response
     http_version: '1.1'
   recorded_at: Tue, 01 Nov 2011 04:49:54 GMT
-recorded_with: VCR 1.11.3
+recorded_with: VCR <%= VCR.version %>

--- a/spec/vcr/cassette/migrator_spec.rb
+++ b/spec/vcr/cassette/migrator_spec.rb
@@ -80,7 +80,7 @@ http_interactions:
     body: Hello bar
     http_version: "1.1"
   recorded_at: Wed, 04 May 2011 12:30:00 GMT
-recorded_with: VCR 1.11.3
+recorded_with: VCR #{VCR.version}
 EOF
   }
 


### PR DESCRIPTION
I think this solves https://github.com/myronmarston/vcr/issues/110
