### PR TITLE
tags_with_prefix for DRY cucumber tagging

### DIFF
--- a/features/test_frameworks/cucumber.feature
+++ b/features/test_frameworks/cucumber.feature
@@ -115,3 +115,91 @@ Feature: Usage with Cucumber
     And the file "features/cassettes/nested_cassette.yml" should contain "body: Hello nested_cassette"
     And the file "features/cassettes/allowed.yml" should contain "body: Hello allowed"
 
+
+
+
+  @exclude-jruby
+  Scenario: Record HTTP interactions in a scenario with prefix based tagging
+    Given a file named "lib/server.rb" with:
+      """ruby
+      if ENV['WITH_SERVER'] == 'true'
+        start_sinatra_app(:port => 7777) do
+          get('/:path') { "Hello #{params[:path]}" }
+        end
+      end
+      """
+    Given a file named "features/vcr_example.feature" with:
+      """
+      Feature: VCR example
+
+        @vcr_localhost_request
+        Scenario: tagged scenario
+          When a request is made to "http://localhost:7777/localhost_request_1"
+          Then the response should be "Hello localhost_request_1"
+          When a request is made to "http://localhost:7777/localhost_request_2"
+          Then the response should be "Hello localhost_request_2"
+
+        @disallowed_call_1
+        Scenario: tagged scenario
+          When a request is made to "http://localhost:7777/allowed" within a cassette named "allowed"
+          Then the response should be "Hello allowed"
+          When a request is made to "http://localhost:7777/disallowed_1"
+
+        @disallowed_call_1
+        Scenario: tagged scenario
+          When a request is made to "http://localhost:7777/disallowed_2"
+      """
+
+    And a file named "features/support/vcr.rb" with:
+      """ruby
+      require "lib/server"
+      require 'vcr'
+
+      VCR.configure do |c|
+        c.hook_into :fakeweb
+        c.cassette_library_dir     = 'features/cassettes'
+      end
+
+      VCR.cucumber_tags do |t|
+        t.tags_with_prefix("vcr")
+        t.tags_with_prefix("disallowed", :record => :none)
+      end
+      """
+    And a file named "features/step_definitions/steps.rb" with:
+      """ruby
+      require 'net/http'
+
+      When /^a request is made to "([^"]*)"$/ do |url|
+        @response = Net::HTTP.get_response(URI.parse(url))
+      end
+
+      When /^(.*) within a cassette named "([^"]*)"$/ do |step, cassette_name|
+        VCR.use_cassette(cassette_name) { When step }
+      end
+
+      Then /^the response should be "([^"]*)"$/ do |expected_response|
+        @response.body.should == expected_response
+      end
+      """
+    And the directory "features/cassettes" does not exist
+    When I run `cucumber WITH_SERVER=true features/vcr_example.feature`
+    Then it should fail with "3 scenarios (2 failed, 1 passed)"
+    And the output should contain each of the following:
+      | An HTTP request has been made that VCR does not know how to handle:               |
+      |   GET http://localhost:7777/disallowed_1                                          |
+      | An HTTP request has been made that VCR does not know how to handle:               |
+      |   GET http://localhost:7777/disallowed_2                                          |
+    And the file "features/cassettes/cucumber_tags/vcr_localhost_request.yml" should contain "body: Hello localhost_request_1"
+    And the file "features/cassettes/cucumber_tags/vcr_localhost_request.yml" should contain "body: Hello localhost_request_2"
+
+    # Run again without the server; we'll get the same responses because VCR
+    # will replay the recorded responses.
+    When I run `cucumber features/vcr_example.feature`
+    Then it should fail with "3 scenarios (2 failed, 1 passed)"
+    And the output should contain each of the following:
+      | An HTTP request has been made that VCR does not know how to handle:               |
+      |   GET http://localhost:7777/disallowed_1                                          |
+      | An HTTP request has been made that VCR does not know how to handle:               |
+      |   GET http://localhost:7777/disallowed_2                                          |
+    And the file "features/cassettes/cucumber_tags/vcr_localhost_request.yml" should contain "body: Hello localhost_request_1"
+    And the file "features/cassettes/cucumber_tags/vcr_localhost_request.yml" should contain "body: Hello localhost_request_2"

--- a/lib/vcr/test_frameworks/cucumber.rb
+++ b/lib/vcr/test_frameworks/cucumber.rb
@@ -47,5 +47,18 @@ module VCR
       end
     end
     alias :tag :tags
+
+    def tags_with_prefix(prefix, options={})
+      tag_regex = /^(\s*(\@\w+)[,]?)+/
+      Dir.glob('**/**.feature').each do |f|
+        contents = File.read(f)
+        cuke_tags = contents.scan(tag_regex).flatten.map(&:strip).uniq
+        prefixed_tags = cuke_tags.select{|x| x.include?("@#{prefix}") }
+        existing_tags = self.class.instance_variable_get("@tags")
+        prefixed_tags -= existing_tags
+        self.tags(*prefixed_tags, options) unless prefixed_tags.empty?
+      end
+    end
   end
+
 end


### PR DESCRIPTION
VCR's cucumber tagging currently requires you to reference each tag in your feature file and in your VCR config.  I wrote a simple prefix tag finder in VCR::CucumberTags so that you only have to type your tags once in the feature file so long as the tags match the prefixes that you specify in your VCR configuration.

```
VCR.cucumber_tags do |t|
   t.tags_with_prefix("vcr")
   t.tags_with_prefix("disallowed", :record => :none)
   t.tag 'this_still_works'
   t.tags 'this_also_works', 'me_too'
end
```
