### PR TITLE
Adds a "before_real_http_request" hook

### DIFF
--- a/features/hooks/before_real_http_request.feature
+++ b/features/hooks/before_real_http_request.feature
@@ -1,0 +1,41 @@
+Feature: before_real_http_request hook
+
+  The `before_real_http_request` hook gets called with each "real" request
+  just before it proceeds. It will not be called for requests that are played-back
+  from cassettes, or when real requests are disabled.
+
+  Scenario Outline: log all requests using a before_real_http_request hook
+    Given a file named "before_real_http_request.rb" with:
+      """ruby
+      include_http_adapter_for("<http_lib>")
+
+      start_sinatra_app(:port => 7777) do
+        get('/') { "Hello World" }
+      end
+
+      require 'vcr'
+
+      VCR.configure do |c|
+        <configuration>
+        c.cassette_library_dir = 'cassettes'
+        c.allow_http_connections_when_no_cassette = true
+        c.before_real_http_request do |request|
+          puts "before real request: #{request.method} #{request.uri}"
+        end
+      end
+
+      make_http_request(:get, "http://localhost:7777/")
+      """
+    When I run `ruby before_real_http_request.rb`
+    Then it should pass with "before real request: get http://localhost:7777/"
+
+   Examples:
+      | configuration         | http_lib              |
+      | c.hook_into :fakeweb  | net/http              |
+      | c.hook_into :webmock  | net/http              |
+      | c.hook_into :webmock  | httpclient            |
+      | c.hook_into :webmock  | curb                  |
+      | c.hook_into :typhoeus | typhoeus              |
+      | c.hook_into :excon    | excon                 |
+      | c.hook_into :faraday  | faraday (w/ net_http) |
+

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -75,6 +75,22 @@ module VCR
     # @see #around_http_request
     define_hook :before_http_request
 
+    # Adds a callback that will be called with each real HTTP request before it is made.
+    #
+    # @example
+    #  VCR.configure do |c|
+    #    c.before_real_http_request do |request|
+    #      puts "Request: #{request.method} #{request.uri}"
+    #    end
+    #  end
+    #
+    # @yield the callback
+    # @yieldparam request [VCR::Request] the request that is being made
+    # @see #before_http_request
+    # @see #after_http_request
+    # @see #around_http_request
+    define_hook :before_real_http_request
+
     # Adds a callback that will be called with each HTTP request after it is complete.
     #
     # @example

--- a/lib/vcr/request_handler.rb
+++ b/lib/vcr/request_handler.rb
@@ -5,7 +5,10 @@ module VCR
       invoke_before_request_hook
       return on_ignored_request    if should_ignore?
       return on_stubbed_request    if stubbed_response
-      return on_recordable_request if VCR.real_http_connections_allowed?
+      if VCR.real_http_connections_allowed?
+        invoke_before_real_request_hook
+        return on_recordable_request
+      end
       on_connection_not_allowed
     end
 
@@ -19,6 +22,11 @@ module VCR
     def invoke_after_request_hook(vcr_response)
       return if disabled?
       VCR.configuration.invoke_hook(:after_http_request, vcr_request, vcr_response)
+    end
+
+    def invoke_before_real_request_hook
+      return if disabled?
+      VCR.configuration.invoke_hook(:before_real_http_request, vcr_request)
     end
 
     def should_ignore?


### PR DESCRIPTION
We had a need to hook into VCR just before doing a real HTTP request (but not when playing back a pre-recorded request). The current hooks didn't help in this scenario ... so here's a small fix to add a "before_real_http_request" hook.
