### PR TITLE
Add VCR::Normalizers::Header#[] for Net::HTTPHeader compatibility

### DIFF
--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -24,6 +24,12 @@ module VCR
         normalize_headers
       end
 
+      # Support the Net::HTTPHeader interface
+      def [](key)
+        v = headers[key] or return nil
+        v.join(', ')
+      end
+
     private
 
       def normalize_headers


### PR DESCRIPTION
The library I'm using VCR on is accessing headers directly from the response object. For example:

``` ruby
header_value = response['header-name']
```

The library in question uses `Net::HTTP`. The `Net::HTTPResponse` class includes the `Net::HTTPHeader` module, which defines `#[]` to access headers directly from the response.

This patch adds support to indexing directly headers from the response object. The code is the same as used in `Net::HTTPHeader`.

I'm happy to add a spec for this change, but I'll need a bit of direction, I have little experience with RSpec.
