### PR TITLE
Allow episode skipping options

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -81,7 +81,7 @@ module VCR
   # @option options :allow_playback_repeats [Boolean] Whether or not to
   #  allow a single HTTP interaction to be played back multiple times.
   #  Defaults to false.
-  # @options options :allow_episode_skipping [Boolean] Wherher or not to
+  # @options options :allow_unused_http_interactions [Boolean] Whether or not to
   #  allow that certain recorded HTTP interactions are not played back
   #  during the use of the cassette. Setting this to false requires that
   #  all interactions will be played back at least once.

--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -66,7 +66,6 @@ module VCR
         should_stub_requests? ? previously_recorded_interactions : [],
         match_requests_on,
         @allow_playback_repeats,
-        @allow_episode_skipping,
         @parent_list,
         log_prefix
     end
@@ -115,8 +114,8 @@ module VCR
     def assert_valid_options!
       invalid_options = @options.keys - [
         :record, :erb, :match_requests_on, :re_record_interval, :tag, :tags,
-        :update_content_length_header, :allow_playback_repeats, :allow_episode_skipping, :exclusive,
-        :serialize_with, :preserve_exact_body_bytes, :decode_compressed_response,
+        :update_content_length_header, :allow_playback_repeats, :allow_unused_http_interactions,
+        :exclusive, :serialize_with, :preserve_exact_body_bytes, :decode_compressed_response,
         :persist_with
       ]
 
@@ -125,9 +124,9 @@ module VCR
       end
     end
 
-    def extract_options
+  def extract_options
       [:erb, :match_requests_on, :re_record_interval,
-       :allow_playback_repeats, :allow_episode_skipping, :exclusive].each do |name|
+       :allow_playback_repeats, :allow_unused_http_interactions, :exclusive].each do |name|
         instance_variable_set("@#{name}", @options[name])
       end
 

--- a/lib/vcr/cassette/http_interaction_list.rb
+++ b/lib/vcr/cassette/http_interaction_list.rb
@@ -13,13 +13,12 @@ module VCR
         def remaining_unused_interaction_count(*a); 0; end
       end
 
-      attr_reader :interactions, :request_matchers, :allow_playback_repeats, :allow_episode_skipping, :parent_list
+      attr_reader :interactions, :request_matchers, :allow_playback_repeats, :parent_list
 
-      def initialize(interactions, request_matchers, allow_playback_repeats = false, allow_episode_skipping = true, parent_list = NullList, log_prefix = '')
+      def initialize(interactions, request_matchers, allow_playback_repeats = false, parent_list = NullList, log_prefix = '')
         @interactions           = interactions.dup
         @request_matchers       = request_matchers
         @allow_playback_repeats = allow_playback_repeats
-        @allow_episode_skipping = allow_episode_skipping
         @parent_list            = parent_list
         @used_interactions      = []
         @log_prefix             = log_prefix
@@ -55,19 +54,19 @@ module VCR
         @interactions.size
       end
 
+      # Checks if there are no unused interactions left.
+      # @raise [VCR::Errors::SkippedHTTPRequestError] when not all interactions were played back
+      #  when allow_episode_skipping is off.
+      def assert_no_unused_interactions!
+        raise Errors::SkippedHTTPRequestError if has_unused_interactions?
+      end
+
+    private
+
       # @return [Boolean] Whether or not there are unused interactions left in the list.
       def has_unused_interactions?
         @interactions.size > 0
       end
-
-      # Checks if we can stop using this interaction list without consequences.
-      # @raise [VCR::Errors::SkippedHTTPRequestError] when not all interactions were played back
-      #  when allow_episode_skipping is off.
-      def assert_finished!
-        raise Errors::SkippedHTTPRequestError if !allow_episode_skipping && has_unused_interactions?
-      end
-
-    private
 
       def request_summary(request)
         super(request, @request_matchers)

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -419,6 +419,7 @@ module VCR
       @default_cassette_options = {
         :record            => :once,
         :match_requests_on => RequestMatcherRegistry::DEFAULT_MATCHERS,
+        :allow_unused_http_interactions => true,
         :serialize_with    => :yaml,
         :persist_with      => :file_system
       }

--- a/spec/vcr/cassette_spec.rb
+++ b/spec/vcr/cassette_spec.rb
@@ -337,14 +337,6 @@ describe VCR::Cassette do
           end
         end
 
-        [true, false].each do |value|
-          it "instantiates the http_interactions with allow_episode_skipping = #{value} if given :allow_episode_skipping => #{value}" do
-            VCR.configuration.cassette_library_dir = "#{VCR::SPEC_ROOT}/fixtures/cassette_spec"
-            cassette = VCR::Cassette.new('example', :record => record_mode, :allow_episode_skipping => value)
-            cassette.http_interactions.allow_episode_skipping.should eq(value)
-          end
-        end
-
         it "instantiates the http_interactions with parent_list set to a null list if given :exclusive => true" do
           VCR.stub(:http_interactions => stub)
           VCR.configuration.cassette_library_dir = "#{VCR::SPEC_ROOT}/fixtures/cassette_spec"

--- a/spec/vcr/configuration_spec.rb
+++ b/spec/vcr/configuration_spec.rb
@@ -25,6 +25,7 @@ describe VCR::Configuration do
     it 'has a hash with some defaults' do
       subject.default_cassette_options.should eq({
         :match_requests_on => VCR::RequestMatcherRegistry::DEFAULT_MATCHERS,
+        :allow_unused_http_interactions => true,
         :record            => :once,
         :serialize_with    => :yaml,
         :persist_with      => :file_system


### PR DESCRIPTION
New option that allows the developer to configure if request interactions can be skipped or not during the usage of a cassette.

Detailed description in #163.
