### PR TITLE
Fix multipart POST requests with Faraday.

### DIFF
--- a/lib/vcr/middleware/faraday.rb
+++ b/lib/vcr/middleware/faraday.rb
@@ -54,10 +54,17 @@ module VCR
         end
 
         def vcr_request
+          if env[:body].respond_to?(:read)
+            body = env[:body].read
+            env[:body].rewind if env[:body].respond_to?(:rewind)
+          else
+            body = env[:body]
+          end
+
           @vcr_request ||= VCR::Request.new \
             env[:method],
             env[:url].to_s,
-            env[:body],
+            body,
             env[:request_headers]
         end
 


### PR DESCRIPTION
VCR isn't properly storing the request body when recording Faraday multipart POST requests. This then causes the matching to fail when using `match_requests_on` with `:body`.

The issue is that Faraday uses the `multipart-post` Gem and returns an instance of `CompositeReadIO` as the request body. Faraday is then calling `#to_s` on the body to "Ensure that the body is a raw string" (`lib/vcr/structs.rb:73`). This causes Farday to store something like `#<Faraday::CompositeReadIO:0x007fd9a119e8d0>` as the request body instead of the actual body Faraday uses by calling `#read` on the body object.

The fix here gets things working, but may not fix it in the best way possible. As I'm new to the VCR codebase, I also wasn't able to determine where or how to write a test for this.
