### PR TITLE
Add effective_url to stubbed Typheous response

### DIFF
--- a/lib/vcr/library_hooks/typhoeus.rb
+++ b/lib/vcr/library_hooks/typhoeus.rb
@@ -50,6 +50,7 @@ else
               :status_message => stubbed_response.status.message,
               :headers        => stubbed_response_headers,
               :body           => stubbed_response.body,
+              :effective_url  => request.url,
               :mock           => true
           end
 


### PR DESCRIPTION
This pull requests adds support for `Typhoeus::Response#effective_url` as documented here:
- http://rubydoc.info/github/typhoeus/typhoeus/Typhoeus/Response/Informations:effective_url

Calling this method on a mocked VCR Typhoeus::Response currently returns nil.  This change makes it return what's expected.

Help me out with a spec for this change - I can't quite parse the way the [library_hooks/typhoeus_spec.rb](https://github.com/myronmarston/vcr/blob/master/spec/vcr/library_hooks/typhoeus_spec.rb) is set up.
