### PR TITLE
Inform contributors that they need to have redis running before they run the specs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ or using the single command form
 git submodule update --init
 ```
 
+Make sure you have redis running on your machine.
+
+```console
+redis-server /usr/local/etc/redis.conf
+```
+
 You should be able to run the tests now:
 
 ```console


### PR DESCRIPTION
I am not sure if there is a better way to handle this but I noticed that one of the features was failing because it could not connect to Redis so I thought a quick updated to the contributing documentation would do the trick.
