### PR TITLE
Cucumber

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,13 +1,14 @@
 <%
+base_opts = '--require features/step_definitions --require features/support'
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'Cucumber::Formatter::Fuubar'} --strict"
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'Cucumber::Formatter::Fuubar'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'Cucumber::Formatter::Fuubar'} --strict"
 
 exclusions = ["--tags ~@exclude-#{RUBY_VERSION.split('.').first(2).join}"].tap do |a|
   a << "--tags ~@exclude-#{RUBY_ENGINE}" if defined?(RUBY_ENGINE)
 end.join(' ')
 %>
-default: <%= std_opts %> --tags ~@wip <%= exclusions %> features
-wip: --tags @wip <%= exclusions %> features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip <%= exclusions %>
+default: <%= base_opts %> <%= std_opts %> --tags ~@wip <%= exclusions %> features
+wip:     <%= base_opts %> --tags @wip <%= exclusions %> features
+rerun:   <%= base_opts %> <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip <%= exclusions %>
 


### PR DESCRIPTION
I can't run individual cucumber specs with the following:

`cucumber features/cassettes/decompress.feature`

I get a bunch of undefined step failures: 

``` cucumber
You can implement step definitions for undefined steps with these snippets:

Given /^a file named "([^"]*)" with:$/ do |arg1, string|
  pending # express the regexp above with the code you wish you had
end

When /^I append to file "([^"]*)":$/ do |arg1, string|
  pending # express the regexp above with the code you wish you had
end

When /^I run `ruby decompress\.rb`$/ do
  pending # express the regexp above with the code you wish you had
end

Then /^the file "([^"]*)" should contain a YAML fragment like:$/ do |arg1, string|
  pending # express the regexp above with the code you wish you had
end

Then /^the file "([^"]*)" should contain:$/ do |arg1, string|
  pending # express the regexp above with the code you wish you had
end
```

Any idea why this would be? I expect some sort of cucumber config problem.
