### PR TITLE
Deprecate #use_vcr_cassette

### DIFF
--- a/lib/vcr/deprecations.rb
+++ b/lib/vcr/deprecations.rb
@@ -42,6 +42,51 @@ module VCR
         end
       end
     end
+
+    module Macros
+      # Sets up a `before` and `after` hook that will insert and eject a
+      # cassette, respectively.
+      #
+      # @example
+      #   describe "Some API Client" do
+      #     use_vcr_cassette "some_api", :record => :new_episodes
+      #   end
+      #
+      # @param [(optional) String] name the cassette name; it will be inferred by the example
+      #  group descriptions if not given.
+      # @param [(optional) Hash] options the cassette options
+      def use_vcr_cassette(*args)
+        Kernel.warn "WARNING: Specifying a cassette with VCR::RSpec::Macros#use_vcr_cassette` is deprecated. \n" +
+          "Use RSpec metadata vcr options instead `:vcr => vcr_options`"
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        name    = args.first || infer_cassette_name
+
+        before(:each) do
+          VCR.insert_cassette(name, options)
+        end
+
+        after(:each) do
+          VCR.eject_cassette
+        end
+      end
+
+      private
+
+      def infer_cassette_name
+        # RSpec 1 exposes #description_parts; use that if its available
+        return description_parts.join("/") if respond_to?(:description_parts)
+
+        # Otherwise use RSpec 2 metadata...
+        group_descriptions = []
+        klass = self
+
+        while klass.respond_to?(:metadata) && klass.metadata
+          group_descriptions << klass.metadata[:example_group][:description]
+          klass = klass.superclass
+        end
+
+        group_descriptions.compact.reverse.join('/')
+      end
+    end
   end
 end
-

--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -13,48 +13,7 @@ module VCR
     #   end
     #
     module Macros
-
-      # Sets up a `before` and `after` hook that will insert and eject a
-      # cassette, respectively.
-      #
-      # @example
-      #   describe "Some API Client" do
-      #     use_vcr_cassette "some_api", :record => :new_episodes
-      #   end
-      #
-      # @param [(optional) String] name the cassette name; it will be inferred by the example
-      #  group descriptions if not given.
-      # @param [(optional) Hash] options the cassette options
-      def use_vcr_cassette(*args)
-        options = args.last.is_a?(Hash) ? args.pop : {}
-        name    = args.first || infer_cassette_name
-
-        before(:each) do
-          VCR.insert_cassette(name, options)
-        end
-
-        after(:each) do
-          VCR.eject_cassette
-        end
-      end
-
-    private
-
-      def infer_cassette_name
-        # RSpec 1 exposes #description_parts; use that if its available
-        return description_parts.join("/") if respond_to?(:description_parts)
-
-        # Otherwise use RSpec 2 metadata...
-        group_descriptions = []
-        klass = self
-
-        while klass.respond_to?(:metadata) && klass.metadata
-          group_descriptions << klass.metadata[:example_group][:description]
-          klass = klass.superclass
-        end
-
-        group_descriptions.compact.reverse.join('/')
-      end
+      include VCR::Deprecations::Macros
     end
 
     # @private
@@ -87,4 +46,3 @@ module VCR
     end
   end
 end
-

--- a/spec/vcr/deprecations_spec.rb
+++ b/spec/vcr/deprecations_spec.rb
@@ -79,5 +79,14 @@ describe VCR, 'deprecations', :disable_warnings do
       VCR::Middleware::Faraday.new(stub) { }
     end
   end
+
+  describe "VCR::RSpec::Macros" do
+    include VCR::RSpec::Macros
+
+    it 'prints a deprecation warning' do
+      Kernel.should_receive(:warn).with(/VCR::RSpec::Macros#use_vcr_cassette` is deprecated/)
+      use_vcr_cassette "foo_cassette"
+    end
+  end
 end
 


### PR DESCRIPTION
This commit fixes #212
- Moved macro to `deprecations.rb`
- Added deprecated message.
