### PR TITLE
Deprecate #use_vcr_cassette

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -24,7 +24,11 @@ module VCR
 
   autoload :CucumberTags,       'vcr/test_frameworks/cucumber'
   autoload :InternetConnection, 'vcr/util/internet_connection'
-  autoload :RSpec,              'vcr/test_frameworks/rspec'
+
+  module RSpec
+    autoload :Metadata,              'vcr/test_frameworks/rspec'
+    autoload :Macros,                'vcr/deprecations'
+  end
 
   module Middleware
     autoload :Faraday,           'vcr/middleware/faraday'

--- a/lib/vcr/deprecations.rb
+++ b/lib/vcr/deprecations.rb
@@ -43,5 +43,66 @@ module VCR
       end
     end
   end
+
+  module RSpec
+    # Contains macro methods to assist with VCR usage. These methods are
+    # intended to be used directly in an RSpec example group. To make these
+    # available in your RSpec example groups, extend the module in an individual
+    # example group, or configure RSpec to extend the module in all example groups.
+    #
+    # @example
+    #   RSpec.configure do |c|
+    #     c.extend VCR::RSpec::Macros
+    #   end
+    #
+    module Macros
+      def self.extended(base)
+        Kernel.warn "WARNING: VCR::RSpec::Macros is deprecated. Use RSpec metadata options instead `:vcr => vcr_options`"
+      end
+
+      # Sets up a `before` and `after` hook that will insert and eject a
+      # cassette, respectively.
+      #
+      # @example
+      #   describe "Some API Client" do
+      #     use_vcr_cassette "some_api", :record => :new_episodes
+      #   end
+      #
+      # @param [(optional) String] name the cassette name; it will be inferred by the example
+      #  group descriptions if not given.
+      # @param [(optional) Hash] options the cassette options
+      # @deprecated Use RSpec metadata options
+      def use_vcr_cassette(*args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        name    = args.first || infer_cassette_name
+
+        before(:each) do
+          VCR.insert_cassette(name, options)
+        end
+
+        after(:each) do
+          VCR.eject_cassette
+        end
+      end
+
+      private
+
+      def infer_cassette_name
+        # RSpec 1 exposes #description_parts; use that if its available
+        return description_parts.join("/") if respond_to?(:description_parts)
+
+        # Otherwise use RSpec 2 metadata...
+        group_descriptions = []
+        klass = self
+
+        while klass.respond_to?(:metadata) && klass.metadata
+          group_descriptions << klass.metadata[:example_group][:description]
+          klass = klass.superclass
+        end
+
+        group_descriptions.compact.reverse.join('/')
+      end
+    end
+  end
 end
 

--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -1,62 +1,6 @@
 module VCR
   # Integrates VCR with RSpec.
   module RSpec
-
-    # Contains macro methods to assist with VCR usage. These methods are
-    # intended to be used directly in an RSpec example group. To make these
-    # available in your RSpec example groups, extend the module in an individual
-    # example group, or configure RSpec to extend the module in all example groups.
-    #
-    # @example
-    #   RSpec.configure do |c|
-    #     c.extend VCR::RSpec::Macros
-    #   end
-    #
-    module Macros
-
-      # Sets up a `before` and `after` hook that will insert and eject a
-      # cassette, respectively.
-      #
-      # @example
-      #   describe "Some API Client" do
-      #     use_vcr_cassette "some_api", :record => :new_episodes
-      #   end
-      #
-      # @param [(optional) String] name the cassette name; it will be inferred by the example
-      #  group descriptions if not given.
-      # @param [(optional) Hash] options the cassette options
-      def use_vcr_cassette(*args)
-        options = args.last.is_a?(Hash) ? args.pop : {}
-        name    = args.first || infer_cassette_name
-
-        before(:each) do
-          VCR.insert_cassette(name, options)
-        end
-
-        after(:each) do
-          VCR.eject_cassette
-        end
-      end
-
-    private
-
-      def infer_cassette_name
-        # RSpec 1 exposes #description_parts; use that if its available
-        return description_parts.join("/") if respond_to?(:description_parts)
-
-        # Otherwise use RSpec 2 metadata...
-        group_descriptions = []
-        klass = self
-
-        while klass.respond_to?(:metadata) && klass.metadata
-          group_descriptions << klass.metadata[:example_group][:description]
-          klass = klass.superclass
-        end
-
-        group_descriptions.compact.reverse.join('/')
-      end
-    end
-
     # @private
     module Metadata
       extend self

--- a/spec/vcr/deprecations_spec.rb
+++ b/spec/vcr/deprecations_spec.rb
@@ -79,5 +79,12 @@ describe VCR, 'deprecations', :disable_warnings do
       VCR::Middleware::Faraday.new(stub) { }
     end
   end
+
+  describe "VCR::RSpec::Macros" do
+    it 'prints a deprecation warning' do
+      Kernel.should_receive(:warn).with(/VCR::RSpec::Macros is deprecated/)
+      Class.new.extend(VCR::RSpec::Macros)
+    end
+  end
 end
 


### PR DESCRIPTION
- This commit fixes #212
- Moved macro to `deprecations.rb`
- Added deprecated message.
