### PR TITLE
Add VCR.cassette_exists? convenience method

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -172,6 +172,17 @@ module VCR
     end
   end
 
+  # Checks if a cassette exists in the cassette library directory.
+  #
+  # @example
+  #   VCR.cassette_exists?('my_cassette_name')
+  #
+  # @return boolean
+  def cassette_exists?(name)
+    file_path = File.join(self.configuration.cassette_library_dir, "#{name}.yml")
+    File.exists? file_path
+  end
+
   # Used to configure VCR.
   #
   # @example

--- a/spec/vcr_spec.rb
+++ b/spec/vcr_spec.rb
@@ -5,6 +5,25 @@ describe VCR do
     VCR.insert_cassette(name)
   end
 
+  describe '.cassette_exists?' do
+    context 'when the given cassette exists' do
+      it 'should return true' do
+        cassette_path = File.join(
+          described_class.configuration.cassette_library_dir,
+          'test.yml'
+        )
+        FileUtils.touch(cassette_path)
+        described_class.cassette_exists?('test').should be_true
+      end
+    end
+
+    context 'when the given cassette does not exist' do
+      it 'should return false' do
+        described_class.cassette_exists?('test').should be_false
+      end
+    end
+  end
+
   describe '.insert_cassette' do
     it 'creates a new cassette' do
       insert_cassette.should be_instance_of(VCR::Cassette)


### PR DESCRIPTION
Can use `VCR.cassette_exists?('my_cassette_name')` to check if cassette exists. Convenience method.
