### PR TITLE
Put parameters back in to URLs created from Typhoeus requests

### DIFF
--- a/spec/vcr/library_hooks/typhoeus_spec.rb
+++ b/spec/vcr/library_hooks/typhoeus_spec.rb
@@ -65,6 +65,29 @@ describe "Typhoeus hook", :with_monkey_patches => :typhoeus do
     end
   end
 
+  context '#url' do
+    it "properly creates urls with parameters" do
+      VCR.use_cassette('single') do
+        response = Typhoeus::Request.new("http://localhost:#{VCR::SinatraApp.port}/", :params => {:foo => 123, :bar => '!! test !!'}).run
+      end
+      saved_stuff = YAML.load_file(VCR::Cassette.new("single").file)
+      saved_stuff['http_interactions'].count.should eq(1)
+      expected = "http://localhost:#{VCR::SinatraApp.port}/?bar=%21%21+test+%21%21&foo=123"
+      saved_stuff['http_interactions'].first['request']['uri'].should eq expected
+    end
+
+    it "properly creates urls with parameters when the url already has a query string" do
+      VCR.use_cassette('single') do
+        response = Typhoeus::Request.new("http://localhost:#{VCR::SinatraApp.port}/?xyz=456&", :params => {:foo => 123, :bar => '!! test !!'}).run
+      end
+      saved_stuff = YAML.load_file(VCR::Cassette.new("single").file)
+      saved_stuff['http_interactions'].count.should eq(1)
+      expected = "http://localhost:#{VCR::SinatraApp.port}/?bar=%21%21+test+%21%21&foo=123&xyz=456"
+      saved_stuff['http_interactions'].first['request']['uri'].should eq expected
+    end
+
+  end
+
   context '#effective_url' do
     def make_single_request
       VCR.use_cassette('single') do


### PR DESCRIPTION
Typhoeus 0.5.0 and above removed parameters from Typhoeus::Request#url .. this pull request makes VCR put them back in and alphabetizes them so matchers continue to work. 

I'm not happy with the way I wrote the tests, but it's my lack of understanding of how the rest of the tests are set up that made them amateurish. This issue was severely blocking us and I couldn't spend as much time taking in the mass of tests as I would like. 

@myronmarston if you think this is worthy, please merge it in -- I just wanted something up for other people in case they also run in to the same issues I did. I agree with you that the real fix is to fix Typhoeus, but changing Typhoeus::Request#url would be a much larger undertaking than to make VCR just deal with the ever-changing API.
