### PR TITLE
Fix issue with `around_http_request` when using multiple threads.

### DIFF
--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -392,13 +392,16 @@ module VCR
         "VCR::Configuration#around_http_request requires fibers, " +
         "which are not available on your ruby intepreter."
     else
-      fiber, hook_allowed, hook_decaration = nil, false, caller.first
+      fibers = {}
+      hook_allowed, hook_decaration = false, caller.first
       before_http_request(*filters) do |request|
         hook_allowed = true
         fiber = start_new_fiber_for(request, block)
+        fibers[Thread.current] = fiber
       end
 
       after_http_request(lambda { hook_allowed }) do |request, response|
+        fiber = fibers.delete(Thread.current)
         resume_fiber(fiber, response, hook_decaration)
       end
     end

--- a/spec/acceptance/threading_spec.rb
+++ b/spec/acceptance/threading_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe VCR do
+  context 'when used in a multithreaded environment', :with_monkey_patches => :excon do
+    def recorded_content_for(name)
+      VCR.cassette_persisters[:file_system]["#{name}.yml"].to_s
+    end
+
+    it 'can use a cassette in an #around_http_request hook', :if => (RUBY_VERSION.to_f > 1.8) do
+      VCR.configure do |vcr|
+        vcr.around_http_request do |req|
+          VCR.use_cassette(req.parsed_uri.path, &req)
+        end
+      end
+
+      thread = Thread.start do
+        Excon.get "http://localhost:#{VCR::SinatraApp.port}/search?q=thread"
+      end
+
+      Excon.get "http://localhost:#{VCR::SinatraApp.port}/foo",
+        :response_block => Proc.new { thread.join }
+
+      expect(recorded_content_for("search") +
+             recorded_content_for("foo")).to include("query: thread", "FOO!")
+    end
+  end
+end
+


### PR DESCRIPTION
Fibers cannot be shared across threads, and you would get an error
when using this feature with threads:

FiberError: fiber called across threads

Actually, we were rescuing FiberError and transforming it into an even more confusing error:

Your around_http_request hook declared at <location> must call #proceed on the yielded request but did not.

Note that VCR is not thread safe (see #200) but this brings it a bit closer.

Fixes #257.
