### PR TITLE
Explicitly require webmock

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Record your test suite's HTTP interactions and replay them during future test ru
 require 'rubygems'
 require 'test/unit'
 require 'vcr'
+require 'webkit'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'fixtures/vcr_cassettes'


### PR DESCRIPTION
For some reason with the latest tag release I had to explicitly require webmock in my Gemfile. Is this not a dependency anymore?
