### PR TITLE
Changes source from :rubygems to https://rubygems.org to remove warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'appraisal'
 


### PR DESCRIPTION
Bundler shows the following warning during bundle install.

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
```
