### PR TITLE
Actually deprecate Typhoeus 0.4 instead of just removing it

### DIFF
--- a/lib/vcr/library_hooks/typhoeus_0.4.rb
+++ b/lib/vcr/library_hooks/typhoeus_0.4.rb
@@ -97,3 +97,7 @@ module Typhoeus
   end unless Hydra.respond_to?(:allow_net_connect_with_vcr?)
 end
 
+VCR.configuration.after_library_hooks_loaded do
+  ::Kernel.warn "WARNING: VCR's Typhoeus 0.4 integration is deprecated and will be removed in VCR 3.0."
+end
+

--- a/spec/monkey_patches.rb
+++ b/spec/monkey_patches.rb
@@ -150,6 +150,7 @@ if defined?(::Typhoeus.before)
   $original_typhoeus_before_hooks = Typhoeus.before.dup
 elsif defined?(::Typhoeus::Hydra.global_hooks)
   require 'vcr/library_hooks/typhoeus'
+  $typhoeus_0_4_after_loaded_hook = VCR.configuration.hooks[:after_library_hooks_loaded].first
   $typhoeus_after_loaded_hook = VCR.configuration.hooks[:after_library_hooks_loaded].last
   $original_typhoeus_global_hooks = Typhoeus::Hydra.global_hooks.dup
   $original_typhoeus_stub_finders = Typhoeus::Hydra.stub_finders.dup

--- a/spec/vcr/library_hooks/typhoeus_0.4_spec.rb
+++ b/spec/vcr/library_hooks/typhoeus_0.4_spec.rb
@@ -26,6 +26,11 @@ describe "Typhoeus 0.4 hook", :with_monkey_patches => :typhoeus_0_4 do
       ::WebMock::HttpLibAdapters::TyphoeusAdapter.should_receive(:disable!)
       $typhoeus_after_loaded_hook.conditionally_invoke
     end
+
+    it "warns about Typhoeus 0.4 deprecation" do
+      ::Kernel.should_receive(:warn).with("WARNING: VCR's Typhoeus 0.4 integration is deprecated and will be removed in VCR 3.0.")
+      $typhoeus_0_4_after_loaded_hook.conditionally_invoke
+    end
   end
 end if RUBY_INTERPRETER == :mri && ::Typhoeus::VERSION.to_f < 0.5
 


### PR DESCRIPTION
Added the deprecation warning for Typhoeus 0.4 in the same way that FakeWeb has a deprecation warning for #277.

For the test, I needed to add access to the typhoeus_0.4 after_loaded_hook. Please let me know if there is a cleaner way.
