### PR TITLE
Added note about setting the cassette_library_dir in Rails.

### DIFF
--- a/features/configuration/cassette_library_dir.feature
+++ b/features/configuration/cassette_library_dir.feature
@@ -3,6 +3,11 @@ Feature: cassette_library_dir
   The `cassette_library_dir` configuration option sets a directory
   where VCR saves each cassette.
 
+  Note: When using Rails, avoid using the `test/fixtures` directory 
+  to store the cassettes. Rails treats any YAML file in the fixtures 
+  directory as an ActiveRecord fixture.
+  This will cause an `ActiveRecord::Fixture::FormatError` to be raised.
+
   Scenario: cassette_library_dir
     Given a file named "cassette_library_dir.rb" with:
       """ruby


### PR DESCRIPTION
I ran into this issue the first time I was setting up vcr, and thought that others may benefit from having it in the docs.

https://relishapp.com/vcr/vcr/v/2-4-0/docs/configuration/cassette-library-dir!

Note: When using Rails, avoid using the `test/fixtures` directory 
 to store the cassettes. Rails treats any YAML file in the fixtures 
 directory as an ActiveRecord fixture.
 This will cause an `ActiveRecord::Fixture::FormatError` to be raised.
