### PR TITLE
Fix code in synopsis to catch up with the change of www.iana.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ end
 class VCRTest < Test::Unit::TestCase
   def test_example_dot_com
     VCR.use_cassette('synopsis') do
-      response = Net::HTTP.get_response(URI('http://www.iana.org/domains/example/'))
-      assert_match /Example Domains/, response.body
+      response = Net::HTTP.get_response(URI('http://www.iana.org/domains/reserved'))
+      assert_match /Example domains/, response.body
     end
   end
 end


### PR DESCRIPTION
Because `http://www.iana.org/domains/example/` has been moved to `http://www.iana.org/domains/reserved` and its content has been changed a bit, the assertion in the code in Synopsis fails. This pull request fixes it.
