### PR TITLE
Don't try to log when there is no logger

### DIFF
--- a/lib/vcr/util/logger.rb
+++ b/lib/vcr/util/logger.rb
@@ -2,16 +2,19 @@ module VCR
   # @private
   module Logger
     def log(message, indentation_level = 0)
+      return unless logger
       indentation = '  ' * indentation_level
       log_message = indentation + log_prefix + message
-      VCR.configuration.debug_logger.puts log_message
+      logger.puts log_message
     end
 
     def log_prefix
+      return unless logger
       ''
     end
 
     def request_summary(request, request_matchers)
+      return unless logger
       attributes = [request.method, request.uri]
       attributes << request.body.to_s[0, 80].inspect if request_matchers.include?(:body)
       attributes << request.headers.inspect          if request_matchers.include?(:headers)
@@ -19,7 +22,12 @@ module VCR
     end
 
     def response_summary(response)
+      return unless logger
       "[#{response.status.code} #{response.body[0, 80].inspect}]"
+    end
+
+    def logger
+      @logger ||= VCR.configuration.debug_logger
     end
   end
 end


### PR DESCRIPTION
If you have a high amount of requests (for instance on a deeply nested SOAP API) the logger starts to be a performance bottleneck. This pull-request enable you to set it to nil so it won't try to log and therefore will be faster.

``` ruby
VCR.configure do |c|
  c.debug_logger = nil
end
```
