### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.
 
-[![Build Status](https://secure.travis-ci.org/vcr/vcr.png?branch=master)](http://travis-ci.org/vcr/vcr)
+[![Build Status](https://secure.travis-ci.org/vcr/vcr.png?branch=master)](http://travis-ci.org/vcr/vcr) [![Code Climate](https://codeclimate.com/github/vcr/vcr.png)](https://codeclimate.com/github/vcr/vcr)
 
 ## Synopsis
 


### PR DESCRIPTION
Hello:

Full disclosure, I work at Code Climate :)

I pulled down vcr recently to help with testing out our new test reporter gem, and noticed you reference Code Climate in your README. Nice.

You have a very nice GPA going right now (3.8), so thought you might enjoy showing it off with our badge. I find that good OSS codebases tend to attract contributions.

Anyhow, thanks for using Code Climate and keep up the good work.
