### PR TITLE
Don't allow RBX failures on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
   allow_failures:
     - rvm: jruby-18mode
     - rvm: jruby-19mode
-    - rvm: rbx-19mode
-    - rvm: rbx-18mode
 branches:
   except:
     - gh-pages


### PR DESCRIPTION
It's passing now.

Fixes #214.
