### PR TITLE
Fix file name sanitization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 [Full Changelog](http://github.com/vcr/vcr/compare/v2.6.0...master)
 
+Enhancements:
 * Explicitly support the latest WebMock releases (1.14 and 1.15).
   (Eduardo Maia, Johannes Würbach)
 * Explicitly support the latest Excon release (0.27). (Myron Marston)
+
+Bug Fixes:
+
 * Fix detection of encoding errors for MultiJson 1.8.1+.
   (Myron Marston).
+* Fix file name sanitization to better handle paths that have
+  a dot in them (Rob Hanlon, Myron Marston).
 
 ## 2.6.0 (September 25, 2013)
 

--- a/lib/vcr/cassette/persisters/file_system.rb
+++ b/lib/vcr/cassette/persisters/file_system.rb
@@ -51,7 +51,11 @@ module VCR
 
         def sanitized_file_name_from(file_name)
           parts = file_name.to_s.split('.')
-          file_extension = '.' + parts.pop if parts.size > 1
+
+          if parts.size > 1 && !parts.last.include?(File::SEPARATOR)
+            file_extension = '.' + parts.pop
+          end
+
           parts.join('.').gsub(/[^\w\-\/]+/, '_') + file_extension.to_s
         end
       end

--- a/spec/vcr/cassette/persisters/file_system_spec.rb
+++ b/spec/vcr/cassette/persisters/file_system_spec.rb
@@ -56,6 +56,11 @@ module VCR
             expected = File.join(FileSystem.storage_location, "a_1/b")
             expect(FileSystem.absolute_path_to_file("a 1/b")).to eq(expected)
           end
+
+          it 'handles files with no extensions (even when there is a dot in the path)' do
+            expected = File.join(FileSystem.storage_location, "/foo_bar/baz_qux")
+            expect(FileSystem.absolute_path_to_file("/foo.bar/baz qux")).to eq(expected)
+          end
         end
       end
     end


### PR DESCRIPTION
This better handles file names with dots in the path
and no file extension.

Fixes #344.
