### PR TITLE
Better submodule handling in ci:setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,19 +7,6 @@ gem install bundler
 bundle install
 ```
 
-Next setup the Git submodules:
-
-```console
-git submodule init
-git submodule update
-```
-
-or using the single command form
-
-```console
-git submodule update --init
-```
-
 You should be able to run the tests now:
 
 ```console

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ end
 require 'cucumber/rake/task'
 Cucumber::Rake::Task.new
 
-task :default => [:spec, :cucumber]
+task :default => [:submodules, :spec, :cucumber]
 
 desc "Ensures we keep up 100% YARD coverage"
 task :yard_coverage do
@@ -49,12 +49,16 @@ task :check_code_coverage do
   end
 end
 
+desc "Checkout git submodules"
+task :submodules do
+  sh "git submodule sync"
+  sh "git submodule update --init --recursive"
+end
+
 namespace :ci do
   desc "Sets things up for a ci build on travis-ci.org"
-  task :setup do
+  task :setup => :submodules do
     ENV['TRAVIS'] = 'true'
-    sh "git submodule init"
-    sh "git submodule update"
   end
 
   RSpec::Core::RakeTask.new(:spec) do |t|

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -13,8 +13,7 @@ bundle install --gemfile=gemfiles/typhoeus_old.gemfile --without extras
 BUNDLE_GEMFILE=gemfiles/typhoeus_old.gemfile bundle exec rspec spec/vcr/library_hooks/typhoeus_0.4_spec.rb --format progress --backtrace
 
 # Setup vendored rspec-1
-git submodule init
-git submodule update
+bundle exec rake submodules
 
 echo "-------- Running Specs ---------"
 bundle exec ruby -I./spec -r./spec/capture_warnings -rspec_helper -S rspec spec --format progress --backtrace


### PR DESCRIPTION
- Checkout git submodules as a DRY rake task.
- Simplify CONTRIBUTING.md and describe warning
  when running `bundle install` for the first time.

Future-proof the test harness:
- Sync submodule URLs in case a future commit changes
  the remote URL of a submodule.
- Atomically update and init git submodules, including
  submodules of submodules.
