### PR TITLE
travis: cache bundle across jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 env: CUCUMBER_FORMAT=progress
+cache: bundler
 bundler_args: --without extras
 script: "script/ci.sh"
 rvm:


### PR DESCRIPTION
Installing dependencies via Bundler can make up a large portion of
the build duration. Caching the bundle between builds drastically
reduces the time a build takes to run.

Caching does not become effective until this commit is merged
to master. At that point, `bundle install` on travis takes
20-30 seconds instead of several minutes. If a branch modifies
the gemspec, then that branch starts with the cache but still
uses the updated gemspec.

In my experience with travis-ci bundler cache, only the default
branch _writes_ the cache. All other branches merely _read_.

http://about.travis-ci.org/docs/user/caching/
