### PR TITLE
Add MIR 2.0.0 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ VCR has been tested on the following ruby interpreters:
 * MRI 1.8.7
 * MRI 1.9.2
 * MRI 1.9.3
+* MRI 2.0.0
 * REE 1.8.7
 * JRuby
 * Rubinius


### PR DESCRIPTION
MRI is already supported and the build is passing in Travis CI. This updates the README to reflect that.
