### PR TITLE
Resolve deprecation warning for rspec 2.99.beta1 and higher

### DIFF
--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -20,7 +20,7 @@ module VCR
           when_tagged_with_vcr = { :vcr => lambda { |v| !!v } }
 
           config.before(:each, when_tagged_with_vcr) do |ex|
-            example = respond_to?(:example) ? self.example : ex
+            example = ex.respond_to?(:metadata) ? ex : ex.example
 
             options = example.metadata[:vcr]
             options = options.is_a?(Hash) ? options.dup : {} # in case it's just :vcr => true
@@ -31,7 +31,7 @@ module VCR
           end
 
           config.after(:each, when_tagged_with_vcr) do |ex|
-            example = respond_to?(:example) ? self.example : ex
+            example = ex.respond_to?(:metadata) ? ex : ex.example
             VCR.eject_cassette(:skip_no_unused_interactions_assertion => !!example.exception)
           end
         end


### PR DESCRIPTION
When testing my project with rspec 2.99.0.beta1, I got a deprecation warning.
I resolved it by this simple change. I tested with the rspec 2.14 and 2.99 both continued working. 
