### PR TITLE
Include the body of the request in the UnhandledHTTPRequestError when matching on the body

### DIFF
--- a/lib/vcr/errors.rb
+++ b/lib/vcr/errors.rb
@@ -96,7 +96,15 @@ module VCR
       end
 
       def match_request_on_body?
-        (VCR.current_cassette && VCR.current_cassette.match_requests_on.include?(:body)) || VCR.configuration.default_cassette_options[:match_requests_on].include?(:body)
+        current_matchers.include?(:body)
+      end
+
+      def current_matchers
+        if VCR.current_cassette
+          VCR.current_cassette.match_requests_on
+        else
+          VCR.configuration.default_cassette_options[:match_requests_on]
+        end
       end
 
       def cassette_description

--- a/spec/vcr/errors_spec.rb
+++ b/spec/vcr/errors_spec.rb
@@ -65,6 +65,15 @@ module VCR
           end
         end
 
+        it 'does not identify the request by its body when the cassette match_requests_on option does not include the body but the default_cassette_options do' do
+          VCR.configuration.default_cassette_options[:match_requests_on] = [:body]
+          VCR.use_cassette('example', :match_requests_on => [:uri]) do
+            expect(message_for(:body => 'param=val1')).to_not include(
+              "Body: param=val1"
+            )
+          end
+        end
+
         it 'mentions the details about the current casette' do
           VCR.use_cassette('example') do
             expect(message).to match(/VCR is currently using the following cassette:.+example.yml/m)


### PR DESCRIPTION
If either the current cassette or the default cassette options include the body as a matcher, show the body of the request in the UnhandledHTTPRequestError to help identify the unhandled request.

I've been working with the FreshBooks API recently, which uses a single URI for all requests and pushes the parameters of the request into the body, so showing just the method/URI when there's an unhandled request is of little help in determining what request is responsible for the error.
