### PR TITLE
Fix readability issues with before_record hook docs

### DIFF
--- a/features/hooks/before_record.feature
+++ b/features/hooks/before_record.feature
@@ -10,8 +10,8 @@ Feature: before_record hook
   If you wish to prevent VCR from recording the HTTP interaction you can call
   `#ignore!` on the interaction.
 
-  If you don't want your hook to apply to all cassettes, you can use tags so
-  you can select which hooks are applied.  Consider this code:
+  If you don't want your hook to apply to all cassettes, you can use tags to
+  select which cassettes a given hook applies to.  Consider this code:
 
       VCR.configure do |c|
         c.before_record(:twitter) { ... } # modify the interactions somehow


### PR DESCRIPTION
From: https://www.relishapp.com/vcr/vcr/v/2-8-0/docs/hooks/before-record-hook

> You can also call `#ignore!` on the HTTP interaction to prevent VCR
> from recording it.
> 
> If you don't your hook to apply to all cassettes, you can use tags for
> this purpose. Consider this code:

The paragraph before these two talk about the arguments a block must accept. The transition to the ability to call `#ignore!` on the interaction doesn't make much sense. The paragraph after it, doesn't make sense either. 

I suspect the two paragraphs should have been in reverse order but I fixed the wording since the example for the second paragraph follows it.
