### PR TITLE
Tiny link typo to Yard [cheat sheet] causing a "Not Found" page error

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note that as of VCR 2, 1.8.6 and 1.9.1 are not supported.
 * See the [Contributing](https://github.com/vcr/vcr/blob/master/CONTRIBUTING.md)
   guide for instructions on running the specs and features.
 * Code quality metrics are checked by [Code Climate](https://codeclimate.com/github/vcr/vcr).
-* Documentation is generated with [YARD](http://yardoc.org/) ([cheat sheet](http://cheat.errtheblog.com/s/yard/)).
+* Documentation is generated with [YARD](http://yardoc.org/) ([cheat sheet](http://cheat.errtheblog.com/s/yard)).
   To generate while developing:
 
 ```


### PR DESCRIPTION
Believe it or not this link http://cheat.errtheblog.com/s/yard/ (with the slash at the end) returns a '404 Not Found' while this one works just fine http://cheat.errtheblog.com/s/yard
