### PR TITLE
Fix issue #378 Rspec integration names file '.yml' when using rspec one ...

### DIFF
--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -11,7 +11,7 @@ module VCR
             description = metadata[:description]
 
             if example_group = metadata[:example_group]
-              [vcr_cassette_name_for[example_group], description].join('/')
+              [vcr_cassette_name_for[example_group], description].reject{|elem| elem.nil? || elem.strip.empty? }.join('/')
             else
               description
             end


### PR DESCRIPTION
Fix issue #378 Rspec integration names file '.yml' when using rspec one line syntax.

When you use rspec one line syntax `it {}` the description is an empty string so the cassette name ends up ending with a `/` then you get an invisible file named `.yml`.
