### PR TITLE
Mark vcr test that use one line rspec syntax as pending

### DIFF
--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -27,7 +27,13 @@ module VCR
 
             cassette_name = options.delete(:cassette_name) ||
                             vcr_cassette_name_for[example.metadata]
-            VCR.insert_cassette(cassette_name, options)
+
+            if cassette_name.strip[-1,1] == "/"
+              pending "VCR does not support rspec one line syntax on line #{example.metadata[:line_number]}"
+            else
+              VCR.insert_cassette(cassette_name, options)
+            end
+            
           end
 
           config.after(:each, when_tagged_with_vcr) do |ex|


### PR DESCRIPTION
I have two solutions for https://github.com/vcr/vcr/issues/378

I prefer this option that marks the test as pending rather then raising an error. 