### PR TITLE
Coerce symbol header keys into strings

### DIFF
--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -119,7 +119,7 @@ module VCR
             else [v]
           end
 
-          new_headers[String.new(k)] = convert_to_raw_strings(val_array)
+          new_headers[String(k)] = convert_to_raw_strings(val_array)
           @normalized_header_keys[k.downcase] = k
         end if headers
 

--- a/spec/vcr/structs_spec.rb
+++ b/spec/vcr/structs_spec.rb
@@ -40,6 +40,11 @@ shared_examples_for "a header normalizer" do
     instance = with_headers('accept-encoding' => accept_encoding)
     expect(instance.headers['accept-encoding']).to eq(accept_encoding)
   end
+
+  it 'coerces symbol header keys into strings' do
+    instance = with_headers(:Accept => ['value'])
+    expect(instance.headers['Accept']).to eq(['value'])
+  end
 end
 
 shared_examples_for "a body normalizer" do


### PR DESCRIPTION
In my codebase there was a request with an `:Accept` header (as a symbol), and I received an error:

```
TypeError: no implicit conversion of Symbol into String
```

After digging, I found this line. I assume `String.new(k)` was supposed to convert anything stringish into a string. However, `String.new` doesn't really have any abilities, as it does implicit conversion, so it errors even when you pass it a symbol (which is as stringish as you can get :grinning:). So I replaced it with `#String`, which does explicit conversion.
