### PR TITLE
Update README gem urls due to repository owner changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ maintenance) and accurate (the response will contain the same headers and body y
   following are supported:
   * [WebMock](https://github.com/bblimke/webmock)
   * [Typhoeus](https://github.com/typhoeus/typhoeus)
-  * [Faraday](https://github.com/technoweenie/faraday)
+  * [Faraday](https://github.com/lostisland/faraday)
   * [Excon](https://github.com/geemus/excon)
   * [FakeWeb](https://github.com/chrisk/fakeweb) (deprecated)
 * Supports multiple HTTP libraries:
@@ -49,9 +49,9 @@ maintenance) and accurate (the response will contain the same headers and body y
   * [Net::HTTP](http://www.ruby-doc.org/stdlib/libdoc/net/http/rdoc/index.html) (when using FakeWeb and WebMock)
   * [Typhoeus](https://github.com/typhoeus/typhoeus) (Typhoeus::Hydra, but not Typhoeus::Easy or Typhoeus::Multi)
   * [Excon](https://github.com/geemus/excon)
-  * [Faraday](https://github.com/technoweenie/faraday)
-  * And of course any library built on Net::HTTP, such as [Mechanize](http://github.com/tenderlove/mechanize),
-    [HTTParty](http://github.com/jnunemaker/httparty) or [Rest Client](http://github.com/archiloque/rest-client).
+  * [Faraday](https://github.com/lostisland/faraday)
+  * And of course any library built on Net::HTTP, such as [Mechanize](http://github.com/sparklemotion/mechanize),
+    [HTTParty](http://github.com/jnunemaker/httparty) or [Rest Client](http://github.com/rest-client/rest-client).
 * Request matching is configurable based on HTTP method, URI, host, path, body and headers, or you can easily
   implement a custom request matcher to handle any need.
 * The same request can receive different responses in different tests--just use different cassettes.


### PR DESCRIPTION
Some gems had their links changed. Noticed that with Faraday but then I checked everyone and got a couple more that needed fixes.

Since @ternderlove removed the mechanize gem from his github account, I could not be sure if the new link is from the legitimate gem maintainer.
