### PR TITLE
bug fix: params with equals sign are truncated

### DIFF
--- a/lib/vcr/request_matcher_registry.rb
+++ b/lib/vcr/request_matcher_registry.rb
@@ -23,7 +23,7 @@ module VCR
 
           uri.query = uri.query.split('&').tap { |params|
             params.map! do |p|
-              key, value = p.split('=')
+              key, value = p.split('=', 2)
               key.gsub!(/\[\]\z/, '') # handle params like tag[]=
               [key, value]
             end

--- a/spec/vcr/request_matcher_registry_spec.rb
+++ b/spec/vcr/request_matcher_registry_spec.rb
@@ -113,6 +113,14 @@ module VCR
           expect(matches).to be true
         end
 
+        it 'does not skips the part of a query parameter value after = symbol' do
+          matches = subject[subject.send(meth, :foo)].matches?(
+            request_with(:uri => 'http://example.com/search?bar=r=1'),
+            request_with(:uri => 'http://example.com/search?bar=r=2')
+          )
+          expect(matches).to be false
+        end
+
         it 'ignores the given query parameters when it is at the end' do
           matches = subject[subject.send(meth, :bar)].matches?(
             request_with(:uri => 'http://example.com/search?foo=124&bar=r'),


### PR DESCRIPTION
if a parameter value contains = sign `URIWithoutParamsMatcher#partial_uri_from` skips it and everything after it thus resulting in an invalid match.