### PR TITLE
fix for auto-generated casette name when "it" block in rspec has no description

### DIFF
--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -16,7 +16,7 @@ module VCR
                             end
 
             if example_group
-              [vcr_cassette_name_for[example_group], description].join('/')
+              [vcr_cassette_name_for[example_group], description].select { |v| !v.empty? }.join('/')
             else
               description
             end


### PR DESCRIPTION
``` ruby
decribe A do
  descirbe 'test', vcr: true do
    before { do_some_http_request }
    subject { true }
    it { should be_true }
  end
end
```

This example generates file named `spec/vcr_cassettes/A/test/.yml` but should generate file named `spec/vcr_cassettes/A/test.yml`
