### PR TITLE
Accept the RECORD environment variable to switch record mode

### DIFF
--- a/features/.nav
+++ b/features/.nav
@@ -20,6 +20,7 @@
   - new_episodes.feature
   - none.feature
   - all.feature
+  - environment_variable.feature
 - configuration:
   - cassette_library_dir.feature
   - hook_into.feature

--- a/features/record_modes/environment_variable.feature
+++ b/features/record_modes/environment_variable.feature
@@ -1,0 +1,78 @@
+Feature: Environment variable
+
+  The environment variable named `RECORD` will:
+
+    - Override record mode.
+
+  This can be temporarily used to switch record mode from command line without
+  changing code.
+
+  Background:
+    Given a file named "setup.rb" with:
+      """ruby
+      start_sinatra_app(:port => 7777) do
+        get('/')    { 'Hello' }
+      end
+
+      require 'vcr'
+
+      VCR.configure do |c|
+        c.hook_into                :webmock
+        c.cassette_library_dir     = 'cassettes'
+      end
+      """
+    And a previously recorded cassette file "cassettes/example.yml" with:
+      """
+      ---
+      http_interactions:
+      - request:
+          method: get
+          uri: http://localhost:7777/
+          body:
+            encoding: UTF-8
+            string: ""
+          headers: {}
+        response:
+          status:
+            code: 200
+            message: OK
+          headers:
+            Content-Length:
+            - "20"
+          body:
+            encoding: UTF-8
+            string: old response
+          http_version: "1.1"
+        recorded_at: Tue, 01 Nov 2011 04:58:44 GMT
+      recorded_with: VCR 2.0.0
+      """
+
+  Scenario: Override record mode with all and re-record previously recorded response
+    Given a file named "override_record_mode_with_all.rb" with:
+      """ruby
+      require 'setup'
+
+      VCR.use_cassette('example') do
+        response = Net::HTTP.get_response('localhost', '/', 7777)
+        puts "Response: #{response.body}"
+      end
+      """
+    When I set the "RECORD" environment variable to "all"
+    And I run `ruby override_record_mode_with_all.rb`
+    Then it should pass with "Response: Hello"
+    And the file "cassettes/example.yml" should contain "Hello"
+    But the file "cassettes/example.yml" should not contain "old response"
+
+  Scenario: Override record mode with none and previously recorded responses are replayed
+    Given a file named "override_record_mode_with_none.rb" with:
+      """ruby
+      require 'setup'
+
+      VCR.use_cassette('example', :record => :all) do
+        response = Net::HTTP.get_response('localhost', '/', 7777)
+        puts "Response: #{response.body}"
+      end
+      """
+    When I set the "RECORD" environment variable to "none"
+    And I run `ruby override_record_mode_with_none.rb`
+    Then it should pass with "Response: old response"

--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -159,6 +159,7 @@ module VCR
       @serializer  = VCR.cassette_serializers[@options[:serialize_with]]
       @persister   = VCR.cassette_persisters[@options[:persist_with]]
       @record_mode = :all if should_re_record?
+      @record_mode = ENV.fetch('RECORD').to_sym if ENV.has_key?('RECORD')
       @parent_list = @exclusive ? HTTPInteractionList::NullList : VCR.http_interactions
     end
 

--- a/spec/vcr/cassette_spec.rb
+++ b/spec/vcr/cassette_spec.rb
@@ -186,6 +186,24 @@ describe VCR::Cassette do
       expect { VCR::Cassette.new(:test, :record => :not_a_record_mode) }.to raise_error(ArgumentError)
     end
 
+    it "overrides record mode if given the 'RECORD' environment variable" do
+      begin
+        ENV['RECORD'] = 'all'
+        expect(VCR::Cassette.new(:test, :record => :none).record_mode).to eql(:all)
+      ensure
+        ENV.delete('RECORD')
+      end
+    end
+
+    it "raises an error if given the 'RECORD' environment variable with an invalid record mode" do
+      begin
+        ENV['RECORD'] = 'not_a_record_mode'
+        expect { VCR::Cassette.new(:test, :record => :none) }.to raise_error(ArgumentError)
+      ensure
+        ENV.delete('RECORD')
+      end
+    end
+
     it 'raises an error if given invalid options' do
       expect {
         VCR::Cassette.new(:test, :invalid => :option)


### PR DESCRIPTION
I'd like to add the ability to switch record mode from command line.
When I working on adding new test suite with TDD cycle, I have to switch `record` mode everytime.
That's pain. And I often commit `record: :all` option by mistake.

So, I'd like to switch record mode temporarily without changing code.
This can be done with `$ RECORD=all rspec spec/under_development_spec.rb:15`.
