### PR TITLE
VCR::Normalizers::Header#normalize_headers now can accept symbols as key...

### DIFF
--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -119,7 +119,7 @@ module VCR
             else [v]
           end
 
-          new_headers[String.new(k)] = convert_to_raw_strings(val_array)
+          new_headers[k.to_s] = convert_to_raw_strings(val_array)
           @normalized_header_keys[k.downcase] = k
         end if headers
 

--- a/spec/vcr/structs_spec.rb
+++ b/spec/vcr/structs_spec.rb
@@ -40,6 +40,12 @@ shared_examples_for "a header normalizer" do
     instance = with_headers('accept-encoding' => accept_encoding)
     expect(instance.headers['accept-encoding']).to eq(accept_encoding)
   end
+
+  it "handles a symbol key" do
+    instance = with_headers(foo: 1)
+    expect(instance.headers['foo']).to eq([1])
+    expect(YAML.dump(instance.headers)).to eq(YAML.dump('foo' => [1]))
+  end
 end
 
 shared_examples_for "a body normalizer" do


### PR DESCRIPTION
This fixes issue #428
