### PR TITLE
Add configuration for forcing utf8 on request / response body

### DIFF
--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -125,6 +125,11 @@ module VCR
       !!@allow_http_connections_when_no_cassette
     end
 
+    attr_writer :force_utf8_encoding
+    def force_utf8_encoding?
+      @force_utf8_encoding
+    end
+
     # Sets a parser for VCR to use when parsing query strings for request
     # comparisons.  The new parser must implement a method `call` that returns
     # an object which is both equalivant and consistent when given an HTTP
@@ -482,6 +487,7 @@ module VCR
 
     def initialize
       @allow_http_connections_when_no_cassette = nil
+      @force_utf8_encoding = false
       @rspec_metadata_configured = false
       @default_cassette_options = {
         :record            => :once,

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -37,7 +37,9 @@ module VCR
             # ASCII-8BIT just means binary, so encoding to it is nonsensical
             # and yet "\u00f6".encode("ASCII-8BIT") raises an error.
             # Instead, we'll force encode it (essentially just tagging it as binary)
-            return string.force_encoding(encoding) if encoding == "ASCII-8BIT"
+            if encoding == "ASCII-8BIT" || VCR.configuration.force_utf8_encoding?
+              return string.force_encoding(encoding)
+            end
 
             string.encode(encoding)
           rescue EncodingError => e
@@ -90,7 +92,11 @@ module VCR
 
       if ''.respond_to?(:encoding)
         def base_body_hash(body)
-          { 'encoding' => body.encoding.name }
+          if VCR.configuration.force_utf8_encoding?
+            { 'encoding' => 'utf-8' }
+          else
+            { 'encoding' => body.encoding.name }
+          end
         end
       else
         def base_body_hash(body)

--- a/spec/support/configuration_stubbing.rb
+++ b/spec/support/configuration_stubbing.rb
@@ -1,5 +1,5 @@
 shared_context "configuration stubbing" do
-  let(:config) { double("VCR::Configuration") }
+  let(:config) { double("VCR::Configuration", force_utf8_encoding?: false) }
 
   before do
     allow(VCR).to receive(:configuration) { config }


### PR DESCRIPTION
Hi!

I've been working with an api that responds with xml data in portuguese. So we have words like "integração" in the response / request body and while data was flowing properly VCR would record only binary data.

Recording as is:

``` yaml
encoding: ASCII-8BIT
string: !binary |-
  w6kgw6kgw6kgw6kgw6kgw6kgw6kgw6kgw6kgw6k=
```

Forcing utf-8:

``` yaml
body:
encoding: utf-8
  string: "é é é é é é é é é é"
```

``` ruby
VCR.use_cassette "check" do
  Net::HTTP.get_response(URI('http://putsreq.herokuapp.com/OXez967BIxgGkizxff4R'))
end
```

While inspecting VCR internals I noticed that it sets the encoding flag of the body based on the `body.encoding` itself and somehow ruby (not sure if VCR or Webmock?) is setting the body encoding as ASCII-8BIT probably due to strings like "integra\xC3\xA7\xC3\xA3o" when what we really want is utf-8.

There's a good chance I'm changing code in the wrong place but this is what I could come up with so far. Would forcing utf8 on body make sense for those scenarios? I'll try to look further to figure where exactly the body gets messy.
