### PR TITLE
Fix cassette names for rspec `it { is_expected }`

### DIFF
--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -16,7 +16,7 @@ module VCR
                             end
 
             if example_group
-              [vcr_cassette_name_for[example_group], description].join('/')
+              [vcr_cassette_name_for[example_group], description].reject(&:empty?).join('/')
             else
               description
             end


### PR DESCRIPTION
Some examples might not have a name. Then cassette names like: `spec/cassettes/client/.yml` were generated.
