### PR TITLE
Updated aruba_timeout_seconds to 60 seconds.

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,7 +24,7 @@ if RUBY_VERSION > '1.9'
 end
 
 Before do
-  @aruba_timeout_seconds = 30
+  @aruba_timeout_seconds = 60
   if "jruby" == ruby_engine
     @aruba_io_wait_seconds = 0.1
   else


### PR DESCRIPTION
An attempt to fix the issue on travis by bumping the `timeout` for child process.