### PR TITLE
Compressed cassettes

### DIFF
--- a/features/cassettes/format.feature
+++ b/features/cassettes/format.feature
@@ -37,6 +37,8 @@ Feature: Cassette format
       you want to ensure that psych is always used.
     - `:json`--Uses [multi_json](https://github.com/intridea/multi_json)
       to serialize the cassette data as JSON.
+    - `:compressed`--Wraps the default YAML serializer with Zlib, writing
+      compressed cassettes to disk.
 
   You can also register a custom serializer using:
 

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -153,6 +153,12 @@ Then(/^the file "([^"]*)" should contain JSON like:$/) do |file_name, expected_c
   expect(normalize_cassette_hash(actual)).to eq(normalize_cassette_hash(expected))
 end
 
+Then(/^the file "([^"]*)" should contain compressed YAML like:$/) do |file_name, expected_content|
+  actual_content = in_current_dir { File.read(file_name) }
+  unzipped_content = Zlib.inflate(actual_content)
+  expect(normalize_cassette_hash(YAML.load(unzipped_content))).to eq(normalize_cassette_hash(YAML.load(expected_content)))
+end
+
 Then(/^the file "([^"]*)" should contain ruby like:$/) do |file_name, expected_content|
   actual_content = in_current_dir { File.read(file_name) }
   actual = eval(actual_content)

--- a/lib/vcr/cassette/serializers.rb
+++ b/lib/vcr/cassette/serializers.rb
@@ -2,10 +2,11 @@ module VCR
   class Cassette
     # Keeps track of the cassette serializers in a hash-like object.
     class Serializers
-      autoload :YAML,  'vcr/cassette/serializers/yaml'
-      autoload :Syck,  'vcr/cassette/serializers/syck'
-      autoload :Psych, 'vcr/cassette/serializers/psych'
-      autoload :JSON,  'vcr/cassette/serializers/json'
+      autoload :YAML,       'vcr/cassette/serializers/yaml'
+      autoload :Syck,       'vcr/cassette/serializers/syck'
+      autoload :Psych,      'vcr/cassette/serializers/psych'
+      autoload :JSON,       'vcr/cassette/serializers/json'
+      autoload :Compressed, 'vcr/cassette/serializers/compressed'
 
       # @private
       def initialize
@@ -20,10 +21,11 @@ module VCR
       def [](name)
         @serializers.fetch(name) do |_|
           @serializers[name] = case name
-            when :yaml  then YAML
-            when :syck  then Syck
-            when :psych then Psych
-            when :json  then JSON
+            when :yaml        then YAML
+            when :syck        then Syck
+            when :psych       then Psych
+            when :json        then JSON
+            when :compressed  then Compressed
             else raise ArgumentError.new("The requested VCR cassette serializer (#{name.inspect}) is not registered.")
           end
         end

--- a/lib/vcr/cassette/serializers/compressed.rb
+++ b/lib/vcr/cassette/serializers/compressed.rb
@@ -7,9 +7,9 @@ module VCR
       # The compressed serializer. This serializer wraps the YAML serializer
       # to write compressed cassettes to disk.
       #
-      # JSON cassettes often compress at greater than 10:1. The tradeoff for
-      # this is that cassettes will not diff nicely or be easily inspectable or
-      # editable.
+      # Cassettes containing responses with JSON data often compress at greater
+      # than 10:1. The tradeoff is that cassettes will not diff nicely or be
+      # easily inspectable or editable.
       #
       # @see YAML
       module Compressed

--- a/lib/vcr/cassette/serializers/compressed.rb
+++ b/lib/vcr/cassette/serializers/compressed.rb
@@ -1,0 +1,45 @@
+require 'zlib'
+require 'vcr/cassette/serializers'
+
+module VCR
+  class Cassette
+    class Serializers
+      # The compressed serializer. This serializer wraps the YAML serializer
+      # to write compressed cassettes to disk.
+      #
+      # JSON cassettes often compress at greater than 10:1. The tradeoff for
+      # this is that cassettes will not diff nicely or be easily inspectable or
+      # editable.
+      #
+      # @see YAML
+      module Compressed
+        extend self
+
+        # The file extension to use for this serializer.
+        #
+        # @return [String] "gz"
+        def file_extension
+          'gz'
+        end
+
+        # Serializes the given hash using YAML and Zlib.
+        #
+        # @param [Hash] hash the object to serialize
+        # @return [String] the compressed cassette data
+        def serialize(hash)
+          string = VCR::Cassette::Serializers::YAML.serialize(hash)
+          Zlib.deflate(string)
+        end
+
+        # Deserializes the given compressed cassette data.
+        #
+        # @param [String] string the compressed YAML cassette data
+        # @return [Hash] the deserialized object
+        def deserialize(string)
+          yaml = Zlib.inflate(string)
+          VCR::Cassette::Serializers::YAML.deserialize(yaml)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/vcr/cassette/serializers_spec.rb
+++ b/spec/lib/vcr/cassette/serializers_spec.rb
@@ -66,6 +66,12 @@ module VCR
         end if ''.respond_to?(:encoding)
       end if RUBY_VERSION =~ /1.9/
 
+      it_behaves_like "a serializer", :compressed, "gz",  :lazily_loaded do
+        it_behaves_like "encoding error handling", :compressed, ArgumentError do
+          let(:string) { "\xFA".force_encoding("UTF-8") }
+        end if ''.respond_to?(:encoding)
+      end
+
       it_behaves_like "a serializer", :json,  "json", :lazily_loaded do
         engines = {}
 


### PR DESCRIPTION
Implements a compressed cassette format.

I had trouble getting the features to run locally with `script/test features/cassettes/format.feature`. There's a ton of errors like:

```
features/cassettes/format.feature:79:in `When I successfully run `ruby cassette_yaml.rb 'Hello'`'

Exit status was 1 but expected it to be 0. Output:

/opt/rubies/2.1.4-github1/lib/ruby/2.1.0/rubygems/version.rb:192:in `new': uninitialized constant Gem::VERSION (NameError)
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/safe_yaml-1.0.4/lib/safe_yaml/libyaml_checker.rb:8:in `<class:LibyamlChecker>'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/safe_yaml-1.0.4/lib/safe_yaml/libyaml_checker.rb:4:in `<module:SafeYAML>'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/safe_yaml-1.0.4/lib/safe_yaml/libyaml_checker.rb:3:in `<top (required)>'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/safe_yaml-1.0.4/lib/safe_yaml/load.rb:10:in `require'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/safe_yaml-1.0.4/lib/safe_yaml/load.rb:10:in `<top (required)>'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/crack-0.4.2/lib/crack/json.rb:6:in `require'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/crack-0.4.2/lib/crack/json.rb:6:in `<top (required)>'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/crack-0.4.2/lib/crack.rb:6:in `require'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/crack-0.4.2/lib/crack.rb:6:in `<top (required)>'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/webmock-1.21.0/lib/webmock.rb:5:in `require'
	from /opt/rubies/2.1.4-github1/lib/ruby/gems/2.1.0/gems/webmock-1.21.0/lib/webmock.rb:5:in `<top (required)>'
	from /Users/ben/repos/vcr/lib/vcr/library_hooks/webmock.rb:3:in `require'
	from /Users/ben/repos/vcr/lib/vcr/library_hooks/webmock.rb:3:in `<top (required)>'
	from /Users/ben/repos/vcr/lib/vcr/configuration.rb:503:in `require'
	from /Users/ben/repos/vcr/lib/vcr/configuration.rb:503:in `load_library_hook'
	from /Users/ben/repos/vcr/lib/vcr/configuration.rb:68:in `block in hook_into'
	from /Users/ben/repos/vcr/lib/vcr/configuration.rb:68:in `each'
	from /Users/ben/repos/vcr/lib/vcr/configuration.rb:68:in `hook_into'
	from cassette_yaml.rb:12:in `block in <main>'
	from /Users/ben/repos/vcr/lib/vcr.rb:199:in `configure'
	from cassette_yaml.rb:11:in `<main>'

 (RSpec::Expectations::ExpectationNotMetError)
```

Do the features needs to be run with a particular ruby version or something?