### PR TITLE
Disable VCR by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ require 'rubygems'
 require 'test/unit'
 require 'vcr'
 
+VCR.turn_on!
 VCR.configure do |config|
   config.cassette_library_dir = "fixtures/vcr_cassettes"
   config.hook_into :webmock # or :fakeweb

--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -340,7 +340,7 @@ private
   end
 
   def initialize_ivars
-    @turned_off = false
+    @turned_off = true
   end
 
   initialize_ivars # to avoid warnings

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -341,9 +341,9 @@ describe VCR do
   end
 
   describe '.turned_on?' do
-    it 'is on by default' do
+    it 'is off by default' do
       VCR.send(:initialize_ivars) # clear internal state
-      expect(VCR).to be_turned_on
+      expect(VCR).to_not be_turned_on
     end
   end
 end


### PR DESCRIPTION
In a TTDed application, a Rails one for example, tests may be correctly passing but when deployed to production, the app may break because the VCR gem was loaded for all environments and is turned on by default. This can easily happen if somebody forgets to add `group: :test` when specifying the gem in the Gemfile.

This pull request turns VCR off by default. The bad thing of this change is that one more step will be needed in the setup, but the good thing is that it will be not possible to break an application just by adding the gem.

What do you think?