### PR TITLE
Use the specs scope as the cassette name when the description is empty

### DIFF
--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -8,7 +8,12 @@ module VCR
       def configure!
         ::RSpec.configure do |config|
           vcr_cassette_name_for = lambda do |metadata|
-            description = metadata[:description]
+            description = if metadata[:description].empty?
+                            # we have an "it { is_expected.to be something }" block
+                            metadata[:scoped_id]
+                          else
+                            metadata[:description]
+                          end
             example_group = if metadata.key?(:example_group)
                               metadata[:example_group]
                             else

--- a/spec/lib/vcr/test_frameworks/rspec_spec.rb
+++ b/spec/lib/vcr/test_frameworks/rspec_spec.rb
@@ -17,6 +17,17 @@ describe VCR::RSpec::Metadata, :skip_vcr_reset do
         ])
       end
     end
+
+    context 'when the spec has no description' do
+      it do
+        expect(VCR.current_cassette.name.split('/')).to eq([
+          'VCR::RSpec::Metadata',
+          'an example group',
+          'when the spec has no description',
+          '1:1:2:1'
+        ])
+      end
+    end
   end
 
   context 'with the cassette name overridden at the example group level', :vcr => { :cassette_name => 'foo' } do


### PR DESCRIPTION
The scope remains relatively stable when new spec are inserted into the suite.
It's not as good as a description, but better than nothing.

Relates to (and possibly fixes) https://github.com/vcr/vcr/issues/378.
This patch helps a lot with `it { is_expected.to be 'something' }`-style specs.
Multiple of those specs overwrite each others cassettes, which is fixed by this patch.

https://github.com/vcr/vcr/issues/378 has a rather long discussion about which cassette name should be used in this case. I'd vote for the scope because
* we don't have a description
* the line number of the specs changes a lot when inserting new specs to the testsuite
* there is no easy way to get the source code of the spec (one could use the `method_source` gem, but it has other limitations for example with dynamically defined specs)

The nested scope does not change when changing existing specs, or appending specs to the suite.