### PR TITLE
make ignore_cassettes a boolean again to prevent nil.dup crashes

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -262,7 +262,7 @@ module VCR
                                 "You must eject it before you can turn VCR off."
     end
 
-    set_context_value(:ignore_cassettes, options[:ignore_cassettes])
+    set_context_value(:ignore_cassettes, options.fetch(:ignore_cassettes, false))
     invalid_options = options.keys - [:ignore_cassettes]
     if invalid_options.any?
       raise ArgumentError.new("You passed some invalid options: #{invalid_options.inspect}")
@@ -376,7 +376,7 @@ private
   def dup_context(context)
     {
       :turned_off => context[:turned_off],
-      :ignore_cassettes => context[:ignore_cassettes].dup,
+      :ignore_cassettes => context[:ignore_cassettes],
       :cassettes => context[:cassettes].dup
     }
   end
@@ -403,7 +403,7 @@ private
     @context = {
       MainThread => {
         :turned_off => false,
-        :ignore_cassettes => [],
+        :ignore_cassettes => false,
         :cassettes => []
       }
     }

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -291,6 +291,11 @@ describe VCR do
       }.to raise_error(ArgumentError)
     end
 
+    it 'sets ignore_cassettes to false' do
+      VCR.turn_off!
+      expect(VCR.send(:ignore_cassettes?)).to equal(false)
+    end
+
     context 'when `:ignore_cassettes => true` is passed' do
       before(:each) { VCR.turn_off!(:ignore_cassettes => true) }
 


### PR DESCRIPTION
According to the documentation turn_off's insert_cassettes is a boolean, if
it is not set as an option it will however be implicitly set to nil since
the thread-safety port. This in turn makes requests fail on nil.dup after
turn_off was called as dup_context would explicitly call dup for
ignore_cassettes.

To prevent this ignore_cassettes is now used as a boolean everywhere again
and defaults to false when turn_off! is called without ignore_cassettes
explicitly set. This should prevent crashes in dup_context.