### PR TITLE
fix(persisters): use binary mode in read/write

### DIFF
--- a/lib/vcr/cassette/persisters/file_system.rb
+++ b/lib/vcr/cassette/persisters/file_system.rb
@@ -23,7 +23,7 @@ module VCR
         def [](file_name)
           path = absolute_path_to_file(file_name)
           return nil unless File.exist?(path)
-          File.read(path)
+          File.binread(path)
         end
 
         # Sets the cassette for the given storage key (file name).
@@ -34,7 +34,7 @@ module VCR
           path = absolute_path_to_file(file_name)
           directory = File.dirname(path)
           FileUtils.mkdir_p(directory) unless File.exist?(directory)
-          File.open(path, 'w') { |f| f.write(content) }
+          File.binwrite(path, content)
         end
 
         # @private
@@ -44,7 +44,6 @@ module VCR
         end
 
       private
-
         def absolute_path_for(path)
           Dir.chdir(path) { Dir.pwd }
         end

--- a/spec/lib/vcr/cassette/persisters/file_system_spec.rb
+++ b/spec/lib/vcr/cassette/persisters/file_system_spec.rb
@@ -25,10 +25,16 @@ module VCR
         end
 
         describe "#[]=" do
-          it 'writes the given file contents to the given file name' do
-            expect(File.exist?(FileSystem.storage_location + '/foo.txt')).to be false
-            FileSystem["foo.txt"] = "bar"
-            expect(File.read(FileSystem.storage_location + '/foo.txt')).to eq("bar")
+          context 'with a simple file_name and binary content' do
+            let(:file_name) { 'foo.txt' }
+            let(:content) { SecureRandom.random_bytes(20) }
+            let(:location) { FileSystem.storage_location + '/' + file_name }
+
+            it 'writes the given file contents to the given file name' do
+              expect(File.exist?(location)).to be false
+              FileSystem[file_name] = content
+              expect(File.binread(location)).to eq(content)
+            end
           end
 
           it 'creates any needed intermediary directories' do

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -273,7 +273,7 @@ describe VCR::Cassette do
 
                 allow(::File).to receive(:exist?).with(file_name).and_return(true)
                 allow(::File).to receive(:size?).with(file_name).and_return(true)
-                allow(::File).to receive(:read).with(file_name).and_return(yaml)
+                allow(::File).to receive(:binread).with(file_name).and_return(yaml)
               end
 
               context 'and the earliest recorded interaction was recorded less than 7 days ago' do


### PR DESCRIPTION
The newly introduced compressed format is not compatible with the standard `File.read` and `File.write` binary mode is needed.