### PR TITLE
change fakeweb message to say 4.0

### DIFF
--- a/lib/vcr/library_hooks/fakeweb.rb
+++ b/lib/vcr/library_hooks/fakeweb.rb
@@ -192,6 +192,6 @@ VCR.configuration.after_library_hooks_loaded do
   if defined?(WebMock)
     raise ArgumentError.new("You have configured VCR to hook into both :fakeweb and :webmock. You cannot use both.")
   end
-  ::Kernel.warn "WARNING: VCR's FakeWeb integration is deprecated and will be removed in VCR 3.0."
+  ::Kernel.warn "WARNING: VCR's FakeWeb integration is deprecated and will be removed in VCR 4.0."
 end
 

--- a/spec/lib/vcr/library_hooks/fakeweb_spec.rb
+++ b/spec/lib/vcr/library_hooks/fakeweb_spec.rb
@@ -129,7 +129,7 @@ describe "FakeWeb hook", :with_monkey_patches => :fakeweb do
       end
 
       it "warns about FakeWeb deprecation" do
-        expect(::Kernel).to receive(:warn).with("WARNING: VCR's FakeWeb integration is deprecated and will be removed in VCR 3.0.")
+        expect(::Kernel).to receive(:warn).with("WARNING: VCR's FakeWeb integration is deprecated and will be removed in VCR 4.0.")
         run_hook
       end
     end


### PR DESCRIPTION
So the last release did not actually remove fakeweb, but the deprecation
warning still says fakeweb will be removed in 3.0.

I have no idea how much removing fakeweb will actually break people's
stuff, but probably the safest thing to do is just keep following
semantic versioning and wait until 4.0 to remove fakeweb.