### PR TITLE
script/ci.sh: use echo instead of printf if doc coverage test failed

### DIFF
--- a/script/ci.sh
+++ b/script/ci.sh
@@ -100,7 +100,7 @@ fold "features" run script/test features/
 check_warnings
 
 if ! bundle exec yard stats --list-undoc | tee /dev/stdout | grep -q '100.00% documented'; then
-  printf "Failed: documentation coverage is less than 100%"
+  echo "Failed: documentation coverage is less than 100%"
   STATUS=1
 fi
 


### PR DESCRIPTION
printf errors if you don't escape the `%` symbol:

```
$ printf "Failed: documentation coverage is less than 100%"
-bash: printf: `%': missing format character
```

It seems fine to just use echo here instead.