### PR TITLE
fix access to the EjectLinkedCassetteError error class

### DIFF
--- a/lib/vcr/linked_cassette.rb
+++ b/lib/vcr/linked_cassette.rb
@@ -60,7 +60,7 @@ module VCR
 
     # Prevents cassette ejection by raising EjectLinkedCassetteError
     def eject(*args)
-      raise EjectLinkedCassetteError,
+      raise Errors::EjectLinkedCassetteError,
         "cannot eject a cassette inserted by a parent thread"
     end
 


### PR DESCRIPTION
Forgot to prefix with Errors module.
Related to https://github.com/vcr/vcr/pull/529