### PR TITLE
remove 1.8.7 support from specs

### DIFF
--- a/spec/lib/vcr/library_hooks/webmock_spec.rb
+++ b/spec/lib/vcr/library_hooks/webmock_spec.rb
@@ -71,7 +71,6 @@ describe "WebMock hook", :with_monkey_patches => :webmock do
   end
 
   http_libs = %w[net/http patron httpclient em-http-request curb typhoeus excon]
-  http_libs.delete('patron') if RUBY_VERSION == '1.8.7'
   http_libs.each do |lib|
     other = []
     other << :status_message_not_exposed if lib == 'excon'

--- a/spec/lib/vcr/middleware/faraday_spec.rb
+++ b/spec/lib/vcr/middleware/faraday_spec.rb
@@ -3,7 +3,6 @@ require 'vcr/library_hooks/faraday'
 
 describe VCR::Middleware::Faraday do
   http_libs = %w[ typhoeus net_http patron ]
-  http_libs.delete('patron') if RUBY_VERSION == '1.8.7'
   http_libs.each do |lib|
     it_behaves_like 'a hook into an HTTP library', :faraday, "faraday (w/ #{lib})",
       :status_message_not_exposed,


### PR DESCRIPTION
Since we removed support for 1.8.7 we don't need this check in the specs.