### PR TITLE
Warning: Do not use test/fixtures, fix #527

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class VCRTest < Test::Unit::TestCase
 end
 ```
 
-Run this test once, and VCR will record the HTTP request to `fixtures/vcr_cassettes/synopsis.yml`.  Run it again, and VCR will replay the response from iana.org when the HTTP request is made.  This test is now fast (no real HTTP requests are made anymore), deterministic (the test will continue to pass, even if you are offline, or iana.org goes down for maintenance) and accurate (the response will contain the same headers and body you get from a real request).
+Run this test once, and VCR will record the HTTP request to `fixtures/vcr_cassettes/synopsis.yml`.  Run it again, and VCR will replay the response from iana.org when the HTTP request is made.  This test is now fast (no real HTTP requests are made anymore), deterministic (the test will continue to pass, even if you are offline, or iana.org goes down for maintenance) and accurate (the response will contain the same headers and body you get from a real request).  You can use a different cassette library directory (e.g., "test/vcr_cassettes"), but do *not* use 'test/fixtures' as the directory if you're using Rails and minitest (Rails will instead transitively load any files in that directory as models).
 
 **Features**
 


### PR DESCRIPTION
The directory 'test/fixtures' *looks* like a reasonable place to put VCR cassettes,
but if you use Rails + minitest the result is a mess (Rails will try to load these as models) -
with very confusing error messages.

Warn people to NOT do this, so that they won't accidentally fall into this trap.