### PR TITLE
Require ruby 1.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ VCR has been tested on the following ruby interpreters:
   * MRI 2.1
   * MRI 2.2
   * MRI 2.3.0
-  * REE 1.8.7
   * JRuby
   * Rubinius
 
-Note that as of VCR 3, 1.8.7, and 1.9.2 are not supported.
+Note that as of VCR 3, 1.8.7 and 1.9.2 are not supported.
 
 **Development**
 

--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir[File.join("test", "**", "*"), File.join("spec", "**", "*"), File.join("features", "**", "*")]
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 1.9.3"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.1.4"


### PR DESCRIPTION
VCR 3.0.1 already does not work with ruby 1.8.7 due to dependency on Fiber, so it should be declared both in gemspec and in README.