### PR TITLE
remove @exclude-18 cucumber tags

### DIFF
--- a/features/configuration/debug_logging.feature
+++ b/features/configuration/debug_logging.feature
@@ -1,4 +1,3 @@
-@exclude-18
 Feature: Debug Logging
 
   Use the `debug_logger` option to set an IO-like object that VCR will log

--- a/features/configuration/hook_into.feature
+++ b/features/configuration/hook_into.feature
@@ -21,7 +21,7 @@ Feature: hook_into
   There are some addiitonal trade offs to consider when deciding which
   option to use:
 
-    - WebMock uses extensive monkey patching to hook into supported HTTP 
+    - WebMock uses extensive monkey patching to hook into supported HTTP
       libraries.  No monkey patching is used for Typhoeus, Excon or Faraday.
     - Typhoeus, Excon, Faraday can be used together, and with either FakeWeb or WebMock.
     - FakeWeb and WebMock cannot both be used at the same time.
@@ -85,7 +85,7 @@ Feature: hook_into
       | c.hook_into :faraday  | faraday (w/ net_http) |
       | c.hook_into :faraday  | faraday (w/ typhoeus) |
 
-  @exclude-jruby @exclude-rbx @exclude-18
+  @exclude-jruby @exclude-rbx
   Scenario Outline: Use Typhoeus, Excon and Faraday in combination with FakeWeb or WebMock
     Given a file named "hook_into_multiple.rb" with:
       """ruby

--- a/features/hooks/around_http_request.feature
+++ b/features/hooks/around_http_request.feature
@@ -1,4 +1,4 @@
-@exclude-18 @exclude-1.9.3p327
+@exclude-1.9.3p327
 Feature: around_http_request hook
 
   The `around_http_request` hook wraps each HTTP request. It can be used


### PR DESCRIPTION
Looks like these tags were for excluding certain cucumber specs to be
run on ruby 1.8, but we don't test on ruby 1.8 anymore, so let's remove
these.