### PR TITLE
restrict the curb version to fix specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ platform :mri do
   gem "typhoeus"
   gem "patron"
   gem "em-http-request"
-  gem "curb"
+  gem "curb", "~> 0.8.8"
 end
 
 platform :ruby do


### PR DESCRIPTION
Fixes this cucumber failure:
```
expected: "Valid encoding: false\n\nRecording:\nBody: \"abc \\xFA\"\n\nPlayback:\nBody: \"abc \\xFA\"\n"
     got: "Valid encoding: false\n\nRecording:\nBody: \"abc \\xFA\"\n\nPlayback:\nBody: \"abc \\xFA\"\nYou are using Curb 0.9.0. WebMock is known to work with Curb >=
0.7.16, < 0.9. It may not work with this version.\n"

(compared using ==)

Diff:
@@ -5,4 +5,5 @@

 Playback:
 Body: "abc \xFA"
+You are using Curb 0.9.0. WebMock is known to work with Curb >= 0.7.16, < 0.9. It may not work with this version.
 (RSpec::Expectations::ExpectationNotMetError)
features/configuration/preserve_exact_body_bytes.feature:55:in `Then the output should contain exactly:'
```