### PR TITLE
Updating the README to support Betamax Java (which is no longer Groovy).

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ yard server --reload
   * [NSURLConnectionVCR](https://bitbucket.org/martijnthe/nsurlconnectionvcr) (Objective-C)
   * [VCRURLConnection](https://github.com/dstnbrkr/VCRURLConnection) (Objective-C)
   * [VHS](https://github.com/diegoeche/vhs) (Erlang)
-  * [Betamax](https://github.com/betamaxteam/betamax) (Groovy/JVM)
+  * [Betamax](https://github.com/betamaxteam/betamax) (Java)
   * [http_replayer](https://github.com/ucarion/http_replayer) (Rust)
 
 **Related Projects**


### PR DESCRIPTION
Betamax (Groovy) is no longer Groovy, it's now Java. Also, Betamax has been revived and is in active development. Would there be objection to moving it higher on the list?