### PR TITLE
enable webmock explicitly

### DIFF
--- a/lib/vcr/library_hooks/webmock.rb
+++ b/lib/vcr/library_hooks/webmock.rb
@@ -4,6 +4,8 @@ require 'webmock'
 
 VCR::VersionChecker.new('WebMock', WebMock.version, '1.8.0').check_version!
 
+WebMock.enable!
+
 module VCR
   class LibraryHooks
     # @private


### PR DESCRIPTION
Starting with webmock 2.0, `WebMock.enable!` needs to be called
explicitly. We should do this for users automatically when they
configure VCR to use webmock.

This seems to be backwards compatible with 1.x versions of webmock.