### PR TITLE
Fix failing Excon tests

### DIFF
--- a/spec/lib/vcr/library_hooks/excon_spec.rb
+++ b/spec/lib/vcr/library_hooks/excon_spec.rb
@@ -60,7 +60,7 @@ describe "Excon hook", :with_monkey_patches => :excon do
 
       expect {
         Excon.get("http://localhost:#{VCR::SinatraApp.port}/404_not_200", :expects => 200)
-      }.to raise_error(Excon::Errors::Error)
+      }.to raise_error(Excon::Error)
     end
 
     def error_raised_by
@@ -88,7 +88,7 @@ describe "Excon hook", :with_monkey_patches => :excon do
       def make_request(disabled = false)
         expect {
           Excon.get(request_url, :expects => 404)
-        }.to raise_error(Excon::Errors::Error)
+        }.to raise_error(Excon::Error)
       end
     end
   end

--- a/spec/support/shared_example_groups/excon.rb
+++ b/spec/support/shared_example_groups/excon.rb
@@ -30,7 +30,7 @@ shared_examples "Excon streaming" do
             Excon.get "http://localhost:#{VCR::SinatraApp.port}/404_not_200", :expects => 200, :response_block => lambda { |chunk, remaining_bytes, total_bytes|
               chunks << chunk
             }
-          rescue Excon::Errors::Error => e
+          rescue Excon::Error => e
             chunks << e.response.body
           end
         end


### PR DESCRIPTION
Excon 0.50.0 renamed `Excon::Errors::Error` to `Excon::Error`.
For backwards compatibility, `Excon::Errors::Error` was redefined as a subclass of `Excon::Error`, but this doesn't help when testing the class of an error raised by Excon.

I've opened an issue on Excon (excon/excon#580) to ask for this to be changed from a subclass to an assignment, which would prevent these failures, but in the meantime, this PR fixes the tests.