### PR TITLE
Allow to continue to play a cassette after errors

### DIFF
--- a/lib/vcr/errors.rb
+++ b/lib/vcr/errors.rb
@@ -88,18 +88,7 @@ module VCR
       end
 
       def current_cassettes
-        @cassettes ||= begin
-          cassettes = VCR.cassettes.to_a.reverse
-
-          begin
-            loop do
-              break unless VCR.eject_cassette
-            end
-          rescue EjectLinkedCassetteError
-          end
-
-          cassettes
-        end
+        @current_cassettes ||= VCR.cassettes.to_a.reverse
       end
 
       def request_description

--- a/spec/lib/vcr/errors_spec.rb
+++ b/spec/lib/vcr/errors_spec.rb
@@ -57,6 +57,18 @@ module VCR
       end
 
       context 'when there are cassettes' do
+        it 'allows to continue to play a cassette even after errors' do
+          VCR.use_cassette('example', :record => :once) do
+            message1 = message
+            expect(message1).to include('An HTTP request has been made that VCR does not know how to handle')
+            expect(message1).not_to include('There is currently no cassette in use')
+
+            message2 = message
+            expect(message2).to include('An HTTP request has been made that VCR does not know how to handle')
+            expect(message2).not_to include('There is currently no cassette in use')
+          end
+        end
+
         it 'identifies the request by its body when the match_requests_on option includes the body' do
           VCR.use_cassette('example', :match_requests_on => [:body]) do
             expect(message_for(:body => 'param=val1')).to include(


### PR DESCRIPTION
Hi, 

I used VCR version `3.0.0` in my application. In one of my tests I made two requests:
- The first one was allowed to fail for any reason. It means that even if it wasn't recorded and failed by VCR ("does not know how to handle") the application should continue working.
- The second request was recorded, so the test should successfully pass.

However, after upgrading it to `3.0.1` the second request didn't play the cassette.

After some bisecting between these 2 versions I found this commit b261b7a. 

The problem is that generating a message for an error ejects cassette. So I would suggest keeping cassettes even after raising a VCR error.
