### PR TITLE
remove test files from built gem

### DIFF
--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir[File.join("lib", "**", "*")]
   spec.executables   = Dir[File.join("bin", "**", "*")].map! { |f| f.gsub(/bin\//, "") }
-  spec.test_files    = Dir[File.join("test", "**", "*"), File.join("spec", "**", "*"), File.join("features", "**", "*")]
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 1.9.3"


### PR DESCRIPTION
I got the idea when we got a similar pull request on resque-web.
https://github.com/resque/resque-web/pull/118

End users shouldn't need the test files and they take up space on disk.

The `test_files` method is left over from when `gem test` was a thing.
https://github.com/rubygems/rubygems/commit/429f883210f8b2b38ea310f7fc6636cd0e456d5c

There is some more discussion on this in a rubygems issue:
https://github.com/rubygems/rubygems/issues/735
