### PR TITLE
set typheous Gem version to ~> 1.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 gem 'jruby-openssl', :platforms => :jruby
 
 platform :mri do
-  gem "typhoeus"
+  gem "typhoeus", "~> 1.0.2"
   gem "patron"
   gem "em-http-request"
   gem "curb", "~> 0.8.8"


### PR DESCRIPTION
Version 1.1.0 seems to break the build.
https://rubygems.org/gems/typhoeus/versions/1.1.0