### PR TITLE
Include Cucumber test suite in the default Rake task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task default: :spec
 
 using_git = File.exist?(File.expand_path('../.git/', __FILE__))
 
-require 'cucumber/rake/task'
+require "cucumber/rake/task"
 Cucumber::Rake::Task.new
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,13 @@ require "rspec/core/rake_task"
 desc "Run all the tests in spec"
 RSpec::Core::RakeTask.new(:spec)
 
-desc "Default: run tests"
-task default: :spec
-
 using_git = File.exist?(File.expand_path('../.git/', __FILE__))
 
 require "cucumber/rake/task"
 Cucumber::Rake::Task.new
 
+desc "Default: run tests"
+task default: [:spec, :cucumber]
 
 def ensure_relish_doc_symlinked(filename)
   from_filename = filename.dup


### PR DESCRIPTION
Run RSpec and Cucumber suites by default when `bundle exec rake` is run from the console, _not just_ RSpec.

- Previously we only ran RSpec, yet we have a reasonably sized Cucumber suite that could get overlooked by contributors.
- Our [CONTRIBUTING.md file](https://github.com/ecnalyr/vcr/blob/master/CONTRIBUTING.md#L10-L14) suggests the default rake task runs our full test suite, this change helps reinforce that idea.