### PR TITLE
Allow rbx-2 to fail without breaking Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ rvm:
 matrix:
   allow_failures:
     - rvm: jruby-19mode
+    - rvm: rbx-2


### PR DESCRIPTION
- The rbx-2 buils fails most of the time on Travis, but not because of a problem with VCR’s codebase.
- Precedence?  Capistrano recently made the same change: https://github.com/capistrano/capistrano/pull/1784

I feel like the red Travis builds are making it _not fun_ to contribute to this project, trying to get our builds green.

This can be undone once rvm releases a new version that includes the fix merged into master that was discussed here: https://github.com/rvm/rvm/issues/3617