### PR TITLE
Configure travis to use the master branch of rvm (so rbx-2 can build).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,10 @@ rvm:
 matrix:
   allow_failures:
     - rvm: jruby-19mode
+# Using `rvm get master` allows builds to obtain rbx-2 until a new version of
+# rvm is released.
+before_install:
+  - rm $rvm_path/user/db
+  - rvm get master
+  - rvm alias delete $RUBY
+  - rvm use $(rvm strings $RUBY) --install --binary


### PR DESCRIPTION
**Note:** This is an alternative to this pr: https://github.com/vcr/vcr/pull/625

- This will allow rbx-2 travis builds to go beyond the ruby-installation phase.
- This will not be necessary when rvm releases a new version that includes the latest commits in master (and travis adopts that version of rvm).