### PR TITLE
Expect Faraday (with certain adapters at least) to support reason phrase

### DIFF
--- a/lib/vcr/middleware/faraday.rb
+++ b/lib/vcr/middleware/faraday.rb
@@ -72,8 +72,12 @@ module VCR
         end
 
         def response_for(response)
+          # reason_phrase is a new addition to Faraday::Response,
+          # so maintain backward compatibility
+          reason = response.respond_to?(:reason_phrase) ? response.reason_phrase : nil
+
           VCR::Response.new(
-            VCR::ResponseStatus.new(response.status, nil),
+            VCR::ResponseStatus.new(response.status, reason),
             response.headers,
             raw_body_from(response.body),
             nil

--- a/spec/lib/vcr/middleware/faraday_spec.rb
+++ b/spec/lib/vcr/middleware/faraday_spec.rb
@@ -4,9 +4,12 @@ require 'vcr/library_hooks/faraday'
 describe VCR::Middleware::Faraday do
   http_libs = %w[ typhoeus net_http patron ]
   http_libs.each do |lib|
-    it_behaves_like 'a hook into an HTTP library', :faraday, "faraday (w/ #{lib})",
-      :status_message_not_exposed,
-      :does_not_support_rotating_responses
+    flags = [ :does_not_support_rotating_responses ]
+    if lib == 'typhoeus'
+      flags << :status_message_not_exposed
+    end
+
+    it_behaves_like 'a hook into an HTTP library', :faraday, "faraday (w/ #{lib})", *flags
   end
 
   context 'when performing a multipart upload' do


### PR DESCRIPTION
Most HTTP lib adapters in Faraday now expose the `reason_phrase` (AKA "status text") of a response. This is useful to me because some of the APIs that I work with put useful information, such as error messages, in the reason phrase. With this change, I can see the reason phrase in my recorded cassettes when using VCR with Faraday.