### PR TITLE
add recompress_response option and hook

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -154,7 +154,7 @@ module VCR
         :record, :erb, :match_requests_on, :re_record_interval, :tag, :tags,
         :update_content_length_header, :allow_playback_repeats, :allow_unused_http_interactions,
         :exclusive, :serialize_with, :preserve_exact_body_bytes, :decode_compressed_response,
-        :persist_with, :clean_outdated_http_interactions
+        :recompress_response, :persist_with, :clean_outdated_http_interactions
       ]
 
       if invalid_options.size > 0
@@ -180,7 +180,7 @@ module VCR
     def assign_tags
       @tags = Array(@options.fetch(:tags) { @options[:tag] })
 
-      [:update_content_length_header, :preserve_exact_body_bytes, :decode_compressed_response].each do |tag|
+      [:update_content_length_header, :preserve_exact_body_bytes, :decode_compressed_response, :recompress_response].each do |tag|
         @tags << tag if @options[tag]
       end
     end

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -559,6 +559,10 @@ module VCR
     end
 
     def register_built_in_hooks
+      before_playback(:recompress_response) do |interaction|
+        interaction.response.recompress if interaction.response.vcr_decompressed?
+      end
+
       before_playback(:update_content_length_header) do |interaction|
         interaction.response.update_content_length_header
       end


### PR DESCRIPTION
this adds a before_playback hook to recompress responses which VCR has decompressed on record. 

I love the option to decompress responses for readability and seeing changes in git diff, but the library I'm working with expects to get a gzipped response back, and errors if the response is not compressed.

I have not yet written tests. I wanted to gauge if this is a feature the maintainers would find desirable to include in VCR before I put in the time. if this would be merged, I'll do the tests.

I'm also not certain I'm not misusing the field `adapter_metadata` - it looked like the most appropriate place to put in information about whether / how VCR decompressed the response, but this isn't exactly related to the adapter.