### PR TITLE
Swap Before Play Log Message Order

### DIFF
--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -222,7 +222,7 @@ module VCR
 
       before_playback(tag) do |interaction|
         orig_text = call_block(block, interaction)
-        log "before_playback: replacing #{placeholder.inspect} with #{orig_text.inspect}"
+        log "before_playback: replacing #{orig_text.inspect} with #{placeholder.inspect}"
         interaction.filter!(placeholder, orig_text)
       end
     end
@@ -571,4 +571,3 @@ module VCR
     define_hook :after_library_hooks_loaded
   end
 end
-


### PR DESCRIPTION
Hello!

Thanks for making `VCR` - it's a great gem!

I was looking through a debug log from VCR `3.0.3` the other day and I noticed an interesting message like this:

```
[VCR::Configuration] before_playback: replacing "<PLACEHOLDER>" with "<ORIGINALVALUE>"
```

After looking at the message, I realized that it really didn't make sense. What's actually happening is that the original text is getting replaced by the `<PLACEHOLDER>`.

This PR simply swaps the two values in the log message. This is also inline with `before_record` log message.