### PR TITLE
Fix Typhoeus/Faraday headers on playback

### DIFF
--- a/lib/vcr/library_hooks/typhoeus.rb
+++ b/lib/vcr/library_hooks/typhoeus.rb
@@ -53,9 +53,10 @@ else
               :effective_url  => stubbed_response.adapter_metadata.fetch('effective_url', request.url),
               :mock           => true
 
+            first_header_line = "HTTP/#{stubbed_response.http_version} #{response.code} #{response.status_message}\r\n"
+            response.instance_variable_set(:@first_header_line, first_header_line)
             response.instance_variable_get(:@options)[:response_headers] =
-              "HTTP/#{response.http_version} #{response.code} #{response.status_message}\r\n" +
-                response.headers.map { |k,v| "#{k}: #{v}"}.join("\r\n")
+              first_header_line + response.headers.map { |k,v| "#{k}: #{v}"}.join("\r\n")
 
             response
           end

--- a/lib/vcr/library_hooks/typhoeus.rb
+++ b/lib/vcr/library_hooks/typhoeus.rb
@@ -44,7 +44,7 @@ else
           end
 
           def on_stubbed_by_vcr_request
-            ::Typhoeus::Response.new \
+            response = ::Typhoeus::Response.new \
               :http_version   => stubbed_response.http_version,
               :code           => stubbed_response.status.code,
               :status_message => stubbed_response.status.message,
@@ -52,6 +52,12 @@ else
               :body           => stubbed_response.body,
               :effective_url  => stubbed_response.adapter_metadata.fetch('effective_url', request.url),
               :mock           => true
+
+            response.instance_variable_get(:@options)[:response_headers] =
+              "HTTP/#{response.http_version} #{response.code} #{response.status_message}\r\n" +
+                response.headers.map { |k,v| "#{k}: #{v}"}.join("\r\n")
+
+            response
           end
 
           def stubbed_response_headers


### PR DESCRIPTION
Apparently due to the way Faraday extracts headers from `Typhoeus::Request` on a live request the headers look like this:

```
 ["HTTP/1.1 200 OK ",
 "Content-Type: text/html;charset=utf-8",
 "Content-Length: 11",
 "Server: WEBrick/1.3.1 (Ruby/2.3.1/2016-04-26)",
 "Date: Sat, 05 Aug 2017 10:42:51 GMT",
 "Connection: Keep-Alive"]
```

When playing back the cassette, however, the HTTP version/status code line was missing, which broke Faraday:

```
["Content-Type: text/html;charset=utf-8",
 "Content-Length: 11",
 "Server: WEBrick/1.3.1 (Ruby/2.3.1/2016-04-26)",
 "Date: Sat, 05 Aug 2017 10:42:51 GMT",
 "Connection: Keep-Alive"]
```
