### PR TITLE
drop unsupported ruby versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: ruby
 script: script/ci.sh
 cache: bundler
 rvm:
-  - '2.0'
-  - '2.1'
   - '2.2'
   - '2.3.0'
   - '2.4.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 script: script/ci.sh
 cache: bundler
 rvm:
-  - '2.2'
+  - '2.2.2'
   - '2.3.0'
   - '2.4.0'
   - jruby-19mode


### PR DESCRIPTION
Will need another version bump for this, but this may make maintenance a bit easier.
Support of ruby 2.1 ended on April 1 2017.
https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/