### PR TITLE
Handle UnusedHTTPInteractionError while constructing UnhandledHTTPRequestError

### DIFF
--- a/lib/vcr/errors.rb
+++ b/lib/vcr/errors.rb
@@ -95,7 +95,7 @@ module VCR
             loop do
               break unless VCR.eject_cassette
             end
-          rescue EjectLinkedCassetteError
+          rescue EjectLinkedCassetteError, UnusedHTTPInteractionError
           end
 
           cassettes

--- a/spec/support/shared_example_groups/hook_into_http_library.rb
+++ b/spec/support/shared_example_groups/hook_into_http_library.rb
@@ -68,6 +68,19 @@ shared_examples_for "a hook into an HTTP library" do |library_hook_name, library
       expect(played_back).to eq(recorded)
     end
 
+    describe "making an HTTP request when :allow_unused_http_interactions is false" do
+      it 'gives a helpful error message for a request not in the cassette' do
+        VCR.eject_cassette
+        VCR.configure do |c|
+          c.cassette_library_dir = File.join(VCR::SPEC_ROOT, 'fixtures')
+        end
+
+        VCR.use_cassette('fake_example_responses', :record => :none, :allow_unused_http_interactions => false) do
+          expect { make_http_request(:get, "http://notincassette/") }.to raise_error(/An HTTP request has been made that VCR does not know how to handle/)
+        end
+      end
+    end
+
     describe 'making an HTTP request' do
       let(:status)        { VCR::ResponseStatus.new(200, 'OK') }
       let(:interaction)   { VCR::HTTPInteraction.new(request, response) }


### PR DESCRIPTION
When VCR raises `UnhandledHTTPRequestError`, it intends to terminate exectuion
of the current test case and give the use a helpful error message.
While constructing `UnhandledHTTPRequestError`, it ejects all cassetees
currently in use to collect them. This has the unfortunate side-effect
of possibly raising `UnusedHTTPInteractionError` if
`allow_unused_http_interactions` is set to false.

The `UnusedHTTPInteractionError` from this situation is misleading.
A test case can consume all the requests in a cassette, but if it
does a superfluous unknown request before doing so, it is terminated
with this error.

This commit catches `UnusedHTTPInteractionError` when constructing
`UnhandledHTTPRequestError` to give a less misleading error message.

Fixes #659 