### PR TITLE
Added configuration option to remove outdated interactions from cassette

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -262,7 +262,7 @@ module VCR
 
       return result unless clean_outdated_http_interactions && re_record_interval
 
-      result.reject { |x| x[:recorded_at] < Time.now - re_record_interval }
+      result.take_while { |x| x[:recorded_at] > Time.now - re_record_interval }
     end
 
     def write_recorded_interactions_to_disk

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -91,6 +91,26 @@ describe VCR::Cassette do
         subject.serializable_hash
       }.not_to change { interaction_1.response.body }
     end
+
+    describe 'clean_outdated_http_interactions' do
+      before(:each) { subject.instance_variable_set(:@clean_outdated_http_interactions, true) }
+      let(:interaction_hashes) { [interaction_1, interaction_2].map(&:to_hash) }
+
+      it "returns all interactions if re_record_interval is not set" do
+        expect(subject.serializable_hash).to include('http_interactions' => interaction_hashes)
+      end
+
+      it "returns all interactions if they are not outdated" do
+        subject.instance_variable_set(:@re_record_interval, 100)
+        expect(subject.serializable_hash).to include('http_interactions' => interaction_hashes)
+      end
+
+      it "rejects outdated interactions" do
+        subject.instance_variable_set(:@re_record_interval, 100)
+        allow(Time).to receive(:now).and_return(Time.now + 105)
+        expect(subject.serializable_hash['http_interactions']).to be_empty
+      end
+    end
   end
 
   describe "#recording?" do

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -93,7 +93,12 @@ describe VCR::Cassette do
     end
 
     describe 'clean_outdated_http_interactions' do
-      before(:each) { subject.instance_variable_set(:@clean_outdated_http_interactions, true) }
+      before(:each) do
+        subject.instance_variable_set(:@clean_outdated_http_interactions, true)
+        subject.instance_variable_set(:@previously_recorded_interactions, subject.instance_variable_get(:@new_recorded_interactions))
+        subject.instance_variable_set(:@new_recorded_interactions, [])
+      end
+
       let(:interaction_hashes) { [interaction_1, interaction_2].map(&:to_hash) }
 
       it "returns all interactions if re_record_interval is not set" do


### PR DESCRIPTION
When on re-record of cassette one or more interactions were not used and remained outdated then next time tests run interactions were re-recorded again. I described it more detailed in #662 

This PR adds cassette option `clean_outdated_http_interactions` that doesn't record outdated interactions back to the cassette file.