### PR TITLE
corresponding to use multiple cassettes

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -192,6 +192,20 @@ module VCR
     end
   end
 
+  # Inserts multiple cassettes the given names
+  #
+  # @example
+  # VCR.use_cassettes(['github', 'apple', 'google]) do
+  #   # make multiple HTTP requests
+  # end
+  def use_cassettes(names, &block)
+    return use_cassette(names.last) { block.call } if names.length == 1
+    cassette = names.pop
+    use_cassette(cassette) do
+      use_cassettes(names, &block)
+    end
+  end
+
   # Used to configure VCR.
   #
   # @example

--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -195,14 +195,18 @@ module VCR
   # Inserts multiple cassettes the given names
   #
   # @example
-  # VCR.use_cassettes(['github', 'apple', 'google]) do
+  # cassettes = [
+  #  { name: 'github' },
+  #  { name: 'apple', options: { erb: true } }
+  # ]
+  # VCR.use_cassettes() do
   #   # make multiple HTTP requests
   # end
-  def use_cassettes(names, &block)
-    return use_cassette(names.last) { block.call } if names.length == 1
-    cassette = names.pop
-    use_cassette(cassette) do
-      use_cassettes(names, &block)
+  def use_cassettes(cassettes, &block)
+    return use_cassette(cassettes.last[:name]) { block.call } if cassettes.length == 1
+    cassette = cassettes.pop
+    use_cassette(cassette[:name], cassette[:options]) do
+      use_cassettes(cassettes, &block)
     end
   end
 

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -351,4 +351,16 @@ describe VCR do
       expect(VCR).to be_turned_on
     end
   end
+
+  describe '.use_cassettes' do
+    it 'use multiple cassettes' do
+      cassette_by_github = VCR::Cassette.new(:use_cassette_test_call_github)
+      cassette_by_apple = VCR::Cassette.new(:use_cassette_test_call_apple)
+
+      expect(VCR).to receive(:insert_cassette).and_return(cassette_by_github)
+      expect(VCR).to receive(:insert_cassette).and_return(cassette_by_apple)
+
+      VCR.use_cassettes([cassette_by_github, cassette_by_apple]) { }
+    end
+  end
 end

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -360,7 +360,12 @@ describe VCR do
       expect(VCR).to receive(:insert_cassette).and_return(cassette_by_github)
       expect(VCR).to receive(:insert_cassette).and_return(cassette_by_apple)
 
-      VCR.use_cassettes([cassette_by_github, cassette_by_apple]) { }
+      cassettes = [
+        { names: cassette_by_github },
+        { names: cassette_by_apple, options: { erb: true } }
+      ]
+
+      VCR.use_cassettes(cassettes) { }
     end
   end
 end


### PR DESCRIPTION
Hi!
Thanks for making VCR!
This is great gem!

# Purpose
I want to use multiple cassettes with one method, I made a method.

# Approach
* defined #use_cassettes in lib/vcr.rb
* It was realized by calling use_cassette recursively.

# Usage  
```
# Inserts multiple cassettes the given names
#
# @example
# VCR.use_cassettes(['github', 'apple', 'google]) do
#   # make multiple HTTP requests
# end
```

Sorry for my poor English.
thank you for reading
