### PR TITLE
CI against ruby 2.2.8, 2.3.5, 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 script: script/ci.sh
 cache: bundler
 rvm:
-  - '2.2.2'
-  - '2.3.0'
-  - '2.4.0'
+  - '2.2.8'
+  - '2.3.5'
+  - '2.4.2'
   - jruby-19mode
   - rbx-2
 matrix:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/