### PR TITLE
Output non-matched headers on error.

### DIFF
--- a/lib/vcr/errors.rb
+++ b/lib/vcr/errors.rb
@@ -107,11 +107,19 @@ module VCR
 
         lines << "  #{request.method.to_s.upcase} #{request.uri}"
 
+        if match_request_on_headers?
+          lines << "  Headers:\n#{formatted_headers}"
+        end
+
         if match_request_on_body?
           lines << "  Body: #{request.body}"
         end
 
         lines.join("\n")
+      end
+
+      def match_request_on_headers?
+        current_matchers.include?(:headers)
       end
 
       def match_request_on_body?
@@ -126,6 +134,14 @@ module VCR
         else
           VCR.configuration.default_cassette_options[:match_requests_on]
         end
+      end
+
+      def formatted_headers
+        request.headers.flat_map do |header, values|
+          values.map do |val|
+            "    #{header}: #{val.inspect}"
+          end
+        end.join("\n")
       end
 
       def cassettes_description


### PR DESCRIPTION
When matching on :headers it's quite difficult to understand why my http
calls don't match the cassettes.