### PR TITLE
Add unignore_hosts method

### DIFF
--- a/features/configuration/ignore_request.feature
+++ b/features/configuration/ignore_request.feature
@@ -16,6 +16,8 @@ Feature: Ignore Request
       VCR with a javascript-enabled capybara driver, since capybara boots
       your rack app and makes localhost requests to it to check that it has
       booted.
+    * `unignore_hosts 'foo.com', 'bar.com'` makes VCR stop ignoring particular
+      hosts.
 
   Ignored requests are not recorded and are always allowed, regardless of
   the record mode, and even outside of a `VCR.use_cassette` block.
@@ -119,6 +121,83 @@ Feature: Ignore Request
       | c.hook_into :excon    | excon                 |
       | c.hook_into :faraday  | faraday (w/ net_http) |
 
+  Scenario Outline: unignored host requests are recorded again
+    Given a file named "unignore_hosts.rb" with:
+      """ruby
+      include_http_adapter_for("<http_lib>")
+      require 'sinatra_app.rb'
+
+      require 'vcr'
+
+      VCR.configure do |c|
+        c.ignore_hosts '127.0.0.1', 'localhost'
+        c.cassette_library_dir = 'cassettes'
+        <configuration>
+      end
+
+      VCR.use_cassette('example') do
+        puts response_body_for(:get, "http://localhost:#{$server.port}/")
+      end
+
+      VCR.configure do |c|
+        c.unignore_hosts '127.0.0.1', 'localhost'
+      end
+
+      VCR.use_cassette('example') do
+        puts response_body_for(:get, "http://localhost:#{$server.port}/")
+      end
+      """
+    When I run `ruby unignore_hosts.rb`
+    Then it should pass with:
+      """
+      Port 7777 Response 1
+      Port 7777 Response 2
+      """
+    And the file "cassettes/example.yml" should not contain "Response 1"
+    And the file "cassettes/example.yml" should contain "Response 2"
+
+    Examples:
+      | configuration         | http_lib              |
+      | c.hook_into :webmock  | net/http              |
+      | c.hook_into :typhoeus | typhoeus              |
+      | c.hook_into :excon    | excon                 |
+      | c.hook_into :faraday  | faraday (w/ net_http) |
+
+  Scenario Outline: unignored host requests are not allowed without a cassette
+    Given a file named "unignore_hosts_without_cassette.rb" with:
+      """ruby
+      include_http_adapter_for("<http_lib>")
+      require 'sinatra_app.rb'
+
+      require 'vcr'
+
+      VCR.configure do |c|
+        c.ignore_hosts '127.0.0.1', 'localhost'
+        c.cassette_library_dir = 'cassettes'
+        <configuration>
+      end
+
+      puts response_body_for(:get, "http://localhost:#{$server.port}/")
+
+      VCR.configure do |c|
+        c.unignore_hosts '127.0.0.1', 'localhost'
+      end
+
+      puts response_body_for(:get, "http://localhost:#{$server.port}/")
+      """
+    When I run `ruby unignore_hosts_without_cassette.rb`
+    Then it should fail with "An HTTP request has been made that VCR does not know how to handle"
+    And the output should contain "Response 1"
+    And the output should not contain "Response 2"
+    And the file "cassettes/example.yml" should not exist
+
+    Examples:
+      | configuration         | http_lib              |
+      | c.hook_into :webmock  | net/http              |
+      | c.hook_into :typhoeus | typhoeus              |
+      | c.hook_into :excon    | excon                 |
+      | c.hook_into :faraday  | faraday (w/ net_http) |
+
   @exclude-jruby
   Scenario Outline: localhost requests are not treated differently by default
     Given a file named "localhost_not_ignored.rb" with:
@@ -185,4 +264,3 @@ Feature: Ignore Request
       | c.hook_into :typhoeus | typhoeus              |
       | c.hook_into :excon    | excon                 |
       | c.hook_into :faraday  | faraday (w/ net_http) |
-

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -77,6 +77,15 @@ module VCR
     end
     alias ignore_host ignore_hosts
 
+    # Specifies host(s) that VCR should stop ignoring.
+    #
+    # @param hosts [Array<String>] List of hosts to unignore
+    # @see #ignore_hosts
+    def unignore_hosts(*hosts)
+      VCR.request_ignorer.unignore_hosts(*hosts)
+    end
+    alias unignore_host unignore_hosts
+
     # Sets whether or not VCR should ignore localhost requests.
     #
     # @param value [Boolean] the value to set
@@ -571,4 +580,3 @@ module VCR
     define_hook :after_library_hooks_loaded
   end
 end
-

--- a/lib/vcr/request_ignorer.rb
+++ b/lib/vcr/request_ignorer.rb
@@ -29,6 +29,10 @@ module VCR
       ignored_hosts.merge(hosts)
     end
 
+    def unignore_hosts(*hosts)
+      ignored_hosts.subtract(hosts)
+    end
+
     def ignore?(request)
       invoke_hook(:ignore_request, request).any?
     end
@@ -40,4 +44,3 @@ module VCR
     end
   end
 end
-

--- a/spec/lib/vcr/configuration_spec.rb
+++ b/spec/lib/vcr/configuration_spec.rb
@@ -94,6 +94,13 @@ describe VCR::Configuration do
     end
   end
 
+  describe '#unignore_hosts' do
+    it 'delegates to the current request_ignorer instance' do
+      expect(VCR.request_ignorer).to receive(:unignore_hosts).with('example.com', 'example.net')
+      subject.unignore_hosts 'example.com', 'example.net'
+    end
+  end
+
   describe '#ignore_localhost=' do
     it 'delegates to the current request_ignorer instance' do
       expect(VCR.request_ignorer).to receive(:ignore_localhost=).with(true)

--- a/spec/lib/vcr/request_ignorer_spec.rb
+++ b/spec/lib/vcr/request_ignorer_spec.rb
@@ -22,6 +22,32 @@ module VCR
       it_behaves_like "#ignore?", "http://some-other-domain.com/", false
     end
 
+    context 'when example.com is unignored' do
+      before(:each) do
+        subject.instance_variable_set(:@ignored_hosts, Set['example.com'])
+        subject.unignore_hosts 'example.com'
+      end
+
+      it_behaves_like "#ignore?", "http://example.com/foo", false
+    end
+
+    context 'when two of three example hosts are unignored' do
+      before(:each) do
+        subject.instance_variable_set(:@ignored_hosts, Set['example.com', 'example.net', 'example.org'])
+        subject.unignore_hosts 'example.com', 'example.net'
+      end
+
+      it_behaves_like "#ignore?", "http://example.com/foo", false
+      it_behaves_like "#ignore?", "http://example.net:890/foo", false
+      it_behaves_like "#ignore?", "https://example.org:890/foo", true
+    end
+
+    context 'when not ignored host is unignored' do
+      it 'no errors should be raised' do
+        expect { subject.unignore_hosts 'example.com' }.not_to raise_error
+      end
+    end
+
     context 'when ignore_localhost is set to true' do
       before(:each) { subject.ignore_localhost = true }
 
@@ -67,4 +93,3 @@ module VCR
     end
   end
 end
-


### PR DESCRIPTION
Remove hosts added to `@ignored_hosts` `Set` with `ignore_hosts`.
Useful in test suites that require the use of cassettes for certain hosts only for certain scenarios.

Example:

```ruby
VCR.configure { |c| c.ignore_hosts 'search.local' }
# Fetch some real data from search service in integration tests

VCR.configure { |c| c.unignore_hosts 'search.local' }
# Stub out search service with a cassette in other tests
```

Fixes #660