### PR TITLE
Add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Ignore autoset environment variables
 /.ruby-env
+/.ruby-version
 
 # Ignore all bundler caching
 /vendor/cache


### PR DESCRIPTION
The `.ruby-version` file is the modern standard for Ruby versioning support (see RVM, rbenv, chruby...).

This PR adds it to `.gitignore`.