### PR TITLE
Remove the last Ruby 1.8 code

### DIFF
--- a/lib/vcr/util/internet_connection.rb
+++ b/lib/vcr/util/internet_connection.rb
@@ -1,31 +1,25 @@
 module VCR
   # Ruby 1.8 provides Ping.pingecho, but it was removed in 1.9.
-  # So we try requiring it, and if that fails, define it ourselves.
-  begin
-    require 'ping'
-    Ping = ::Ping
-  rescue LoadError
-    # This is copied, verbatim, from Ruby 1.8.7's ping.rb.
-    require 'timeout'
-    require "socket"
+  # This is copied, verbatim, from Ruby 1.8.7's ping.rb.
+  require 'timeout'
+  require "socket"
 
-    # @private
-    module Ping
-      def pingecho(host, timeout=5, service="echo")
-        begin
-          Timeout.timeout(timeout) do
-            s = TCPSocket.new(host, service)
-            s.close
-          end
-        rescue Errno::ECONNREFUSED
-          return true
-        rescue Timeout::Error, StandardError
-          return false
+  # @private
+  module Ping
+    def pingecho(host, timeout=5, service="echo")
+      begin
+        Timeout.timeout(timeout) do
+          s = TCPSocket.new(host, service)
+          s.close
         end
+      rescue Errno::ECONNREFUSED
         return true
+      rescue Timeout::Error, StandardError
+        return false
       end
-      module_function :pingecho
+      return true
     end
+    module_function :pingecho
   end
 
   # @private


### PR DESCRIPTION
Remove Ruby 1.8 Ping code from util/internet_connection.rb.

This is the last Ruby 1.8 code, and closes #676.