### PR TITLE
Fix Code Climate badges URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 vcr
 ===
 
-[![Quality](https://img.shields.io/codeclimate/github/vcr/vcr.svg?style=flat-square)](https://codeclimate.com/github/vcr/vcr)
-[![Coverage](https://img.shields.io/codeclimate/coverage/github/vcr/vcr.svg?style=flat-square)](https://codeclimate.com/github/vcr/vcr)
+[![Maintainability](https://img.shields.io/codeclimate/maintainability/vcr/vcr.svg?style=flat-square)](https://codeclimate.com/github/vcr/vcr)
+[![Coverage](https://img.shields.io/codeclimate/c/vcr/vcr.svg?style=flat-square)](https://codeclimate.com/github/vcr/vcr)
 [![Build](https://img.shields.io/travis-ci/vcr/vcr.svg?style=flat-square)](https://travis-ci.org/vcr/vcr)
 [![Dependencies](https://img.shields.io/gemnasium/vcr/vcr.svg?style=flat-square)](https://gemnasium.com/vcr/vcr)
 [![Downloads](https://img.shields.io/gem/dtv/vcr.svg?style=flat-square)](https://rubygems.org/gems/vcr)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ vcr
 ===
 
 [![Maintainability](https://img.shields.io/codeclimate/maintainability/vcr/vcr.svg?style=flat-square)](https://codeclimate.com/github/vcr/vcr)
-[![Coverage](https://img.shields.io/codeclimate/c/vcr/vcr.svg?style=flat-square)](https://codeclimate.com/github/vcr/vcr)
+[![Coverage](https://img.shields.io/codeclimate/coverage/vcr/vcr.svg?style=flat-square)](https://codeclimate.com/github/vcr/vcr)
 [![Build](https://img.shields.io/travis-ci/vcr/vcr.svg?style=flat-square)](https://travis-ci.org/vcr/vcr)
 [![Dependencies](https://img.shields.io/gemnasium/vcr/vcr.svg?style=flat-square)](https://gemnasium.com/vcr/vcr)
 [![Downloads](https://img.shields.io/gem/dtv/vcr.svg?style=flat-square)](https://rubygems.org/gems/vcr)


### PR DESCRIPTION
The Code Climate badges from shields.io are being refactored to comply with upstream changes, so the old URLs are not working anymore.
While we wait for the final version of the fix to be pushed to production, this PR adds support for the `maintainability` and `coverage` letter grade.