### PR TITLE
Prevent storing empty http_version on cassettes

### DIFF
--- a/features/http_libraries/em_http_request.feature
+++ b/features/http_libraries/em_http_request.feature
@@ -83,7 +83,6 @@ Feature: EM HTTP Request
           body: 
             encoding: UTF-8
             string: Hello foo
-          http_version: 
         recorded_at: Tue, 01 Nov 2011 04:58:44 GMT
       - request: 
           method: get
@@ -104,7 +103,6 @@ Feature: EM HTTP Request
           body: 
             encoding: UTF-8
             string: Hello bar
-          http_version: 
         recorded_at: Tue, 01 Nov 2011 04:58:44 GMT
       - request: 
           method: get
@@ -125,7 +123,6 @@ Feature: EM HTTP Request
           body: 
             encoding: UTF-8
             string: Hello bazz
-          http_version: 
         recorded_at: Tue, 01 Nov 2011 04:58:44 GMT
       recorded_with: VCR 2.0.0
       """
@@ -193,7 +190,6 @@ Feature: EM HTTP Request
           body: 
             encoding: UTF-8
             string: Hello foo
-          http_version: 
         recorded_at: Tue, 01 Nov 2011 04:58:44 GMT
       - request: 
           method: get
@@ -214,7 +210,6 @@ Feature: EM HTTP Request
           body: 
             encoding: UTF-8
             string: Hello bar
-          http_version: 
         recorded_at: Tue, 01 Nov 2011 04:58:44 GMT
       - request: 
           method: get
@@ -235,7 +230,6 @@ Feature: EM HTTP Request
           body: 
             encoding: UTF-8
             string: Hello bazz
-          http_version: 
         recorded_at: Tue, 01 Nov 2011 04:58:44 GMT
       recorded_with: VCR 2.0.0
       """

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -346,9 +346,9 @@ module VCR
       {
         'status'       => status.to_hash,
         'headers'      => headers,
-        'body'         => serializable_body,
-        'http_version' => http_version
+        'body'         => serializable_body
       }.tap do |hash|
+        hash['http_version']     = http_version if http_version
         hash['adapter_metadata'] = adapter_metadata unless adapter_metadata.empty?
       end
     end


### PR DESCRIPTION
Fixes #703 and should keep compativility with cassettes recorded before.