### PR TITLE
disable the webmock excon adapter

### DIFF
--- a/lib/vcr/library_hooks/excon.rb
+++ b/lib/vcr/library_hooks/excon.rb
@@ -22,6 +22,14 @@ VCR.configuration.after_library_hooks_loaded do
   # (i.e. to double record requests or whatever).
   if defined?(WebMock::HttpLibAdapters::ExconAdapter)
     WebMock::HttpLibAdapters::ExconAdapter.disable!
+
+    if defined?(::RSpec)
+      ::RSpec.configure do |config|
+        config.before(:suite) do
+          WebMock::HttpLibAdapters::ExconAdapter.disable!
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Webmock changed when it gets enabled from when it's initially loaded to right before the rspec suite is ran. (see here for the diff https://github.com/bblimke/webmock/commit/d9af3a54d73c7de1cc16cf19e05b2522c4f7d093#diff-716564b83a1cd2a4dd19999e263d60f4)

This PR will make it so that if the webmock excon adapter is present, and we're using rspec, we disable the webmock excon adapter before the rspec test suite runs. This should keep vcr compatible with current versions of webmock