### PR TITLE
Compare JSON bodies quicker by checking for string equivalence first

### DIFF
--- a/lib/vcr/request_matcher_registry.rb
+++ b/lib/vcr/request_matcher_registry.rb
@@ -138,7 +138,7 @@ module VCR
 
       register(:body_as_json) do |r1, r2|
         begin
-          JSON.parse(r1.body) == JSON.parse(r2.body)
+          r1.body == r2.body || JSON.parse(r1.body) == JSON.parse(r2.body)
         rescue JSON::ParserError
           false
         end

--- a/spec/lib/vcr/request_matcher_registry_spec.rb
+++ b/spec/lib/vcr/request_matcher_registry_spec.rb
@@ -278,14 +278,6 @@ module VCR
           )
           expect(matches).to be false
         end
-
-        it 'does not match when body is not json' do
-          matches = subject[:body_as_json].matches?(
-            request_with(:body => 'a=b'),
-            request_with(:body => 'a=b')
-          )
-          expect(matches).to be false
-        end
       end
 
       describe ":headers" do


### PR DESCRIPTION
For identical bodies, comparison can be improved by a few orders of magnitude. For equivalent (but not identical) and different bodies, the difference is negligible. My benchmark script and local results are included below. Thank you! 👏

<details>
<summary>Benchmark script</summary>
    
    # frozen_string_literal: true

    begin
      require "benchmark/ips"
      require "faker"
      require "json"
    rescue LoadError
      abort "Please `gem install benchmark-ips faker json` first!"
    end

    data = Faker::Types.complex_rb_hash(1000)
    body = JSON.generate(Faker::Types.complex_rb_hash(1000))

    identical_body = body.dup
    equivalent_body = JSON.pretty_generate(data)
    different_body = JSON.generate(data.merge(different: true))
    very_different_body = JSON.generate(Faker::Types.complex_rb_hash(1000))

    def test(body_1, body_2)
      Benchmark.ips do |x|
        x.report "original" do
          JSON.parse(body_1) == JSON.parse(body_2)
        end

        x.report "improved" do
          body_1 == body_2 || JSON.parse(body_1) == JSON.parse(body_2)
        end

        x.compare!
      end
    end

    puts "IDENTICAL BODIES"
    test(body, identical_body)

    puts "EQUIVALENT BODIES"
    test(body, equivalent_body)

    puts "DIFFERENT BODIES"
    test(body, different_body)

    puts "VERY DIFFERENT BODIES"
    test(body, very_different_body)
</details>

<details>
<summary>Benchmark results</summary>

    IDENTICAL BODIES
    Warming up --------------------------------------
                original   272.000  i/100ms
                improved   307.430k i/100ms
    Calculating -------------------------------------
                original      2.735k (± 3.5%) i/s -     13.872k in   5.078274s
                improved     10.089M (± 4.0%) i/s -     50.419M in   5.006029s

    Comparison:
                improved: 10089399.2 i/s
                original:     2735.0 i/s - 3688.97x  slower

    EQUIVALENT BODIES
    Warming up --------------------------------------
                original   313.000  i/100ms
                improved   298.000  i/100ms
    Calculating -------------------------------------
                original      3.080k (± 3.4%) i/s -     15.650k in   5.088047s
                improved      3.129k (± 2.8%) i/s -     15.794k in   5.051086s

    Comparison:
                improved:     3129.4 i/s
                original:     3079.6 i/s - same-ish: difference falls within error

    DIFFERENT BODIES
    Warming up --------------------------------------
                original   315.000  i/100ms
                improved   314.000  i/100ms
    Calculating -------------------------------------
                original      3.189k (± 2.7%) i/s -     16.065k in   5.041486s
                improved      3.163k (± 4.4%) i/s -     16.014k in   5.074614s

    Comparison:
                original:     3188.9 i/s
                improved:     3162.8 i/s - same-ish: difference falls within error

    VERY DIFFERENT BODIES
    Warming up --------------------------------------
                original   308.000  i/100ms
                improved   314.000  i/100ms
    Calculating -------------------------------------
                original      3.154k (± 2.5%) i/s -     16.016k in   5.081594s
                improved      3.064k (± 4.5%) i/s -     15.386k in   5.032466s

    Comparison:
                original:     3153.9 i/s
                improved:     3063.9 i/s - same-ish: difference falls within error

</details>