### PR TITLE
Bump Typhoeus to 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 gem 'jruby-openssl', :platforms => :jruby
 
 platform :mri do
-  gem "typhoeus", "~> 1.0.2"
+  gem "typhoeus", "~> 1.1.0"
   gem "patron", "0.6.3"
   gem "em-http-request"
   gem "curb", "~> 0.8.8"

--- a/spec/support/http_library_adapters.rb
+++ b/spec/support/http_library_adapters.rb
@@ -183,7 +183,7 @@ HTTP_LIBRARY_ADAPTERS['typhoeus'] = Module.new do
   end
 
   def normalize_request_headers(headers)
-    headers.merge("User-Agent"=>["Typhoeus - https://github.com/typhoeus/typhoeus"])
+    headers.merge("User-Agent"=>["Typhoeus - https://github.com/typhoeus/typhoeus"], 'Expect' => [''])
   end
 end
 


### PR DESCRIPTION
Which always set the Expect header since 1.1.0.

See https://github.com/typhoeus/typhoeus/commit/869c36b8f848ff8bb4838397b2803890a869bd53