### PR TITLE
Fix VCR.use_cassettes method implementation and spec

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -202,10 +202,13 @@ module VCR
   #   # make multiple HTTP requests
   # end
   def use_cassettes(cassettes, &block)
-    return use_cassette(cassettes.last[:name]) { block.call } if cassettes.length == 1
     cassette = cassettes.pop
-    use_cassette(cassette[:name], cassette[:options]) do
-      use_cassettes(cassettes, &block)
+    use_cassette(cassette[:name], cassette[:options] || {}) do
+      if cassettes.empty?
+        block.call
+      else
+        use_cassettes(cassettes, &block)
+      end
     end
   end
 

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -353,16 +353,16 @@ describe VCR do
   end
 
   describe '.use_cassettes' do
-    it 'use multiple cassettes' do
+    it 'uses multiple cassettes' do
       cassette_by_github = VCR::Cassette.new(:use_cassette_test_call_github)
       cassette_by_apple = VCR::Cassette.new(:use_cassette_test_call_apple)
 
-      expect(VCR).to receive(:insert_cassette).and_return(cassette_by_github)
-      expect(VCR).to receive(:insert_cassette).and_return(cassette_by_apple)
+      expect(VCR).to receive(:insert_cassette).with(cassette_by_github, {}).and_return(cassette_by_github)
+      expect(VCR).to receive(:insert_cassette).with(cassette_by_apple, { erb: true }).and_return(cassette_by_apple)
 
       cassettes = [
-        { names: cassette_by_github },
-        { names: cassette_by_apple, options: { erb: true } }
+        { name: cassette_by_github },
+        { name: cassette_by_apple, options: { erb: true } }
       ]
 
       VCR.use_cassettes(cassettes) { }


### PR DESCRIPTION
- update VCR.use_cassettes spec to test method arguments
- fix VCR.use_cassettes raises `no implicit conversion of nil into Hash`