### PR TITLE
Fix flaws in VCR.use_cassettes helper

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -202,9 +202,9 @@ module VCR
   #   # make multiple HTTP requests
   # end
   def use_cassettes(cassettes, &block)
-    return use_cassette(cassettes.last[:name]) { block.call } if cassettes.length == 1
+    return use_cassette(cassettes.last[:name], cassettes.last[:options] || {}) { block.call } if cassettes.length == 1
     cassette = cassettes.pop
-    use_cassette(cassette[:name], cassette[:options]) do
+    use_cassette(cassette[:name], cassette[:options] || {}) do
       use_cassettes(cassettes, &block)
     end
   end

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -354,18 +354,21 @@ describe VCR do
 
   describe '.use_cassettes' do
     it 'use multiple cassettes' do
-      cassette_by_github = VCR::Cassette.new(:use_cassette_test_call_github)
-      cassette_by_apple = VCR::Cassette.new(:use_cassette_test_call_apple)
-
-      expect(VCR).to receive(:insert_cassette).and_return(cassette_by_github)
-      expect(VCR).to receive(:insert_cassette).and_return(cassette_by_apple)
+      allow(VCR).to receive(:insert_cassette)
 
       cassettes = [
-        { names: cassette_by_github },
-        { names: cassette_by_apple, options: { erb: true } }
+        { name: :use_cassette_test_call_github },
+        { name: :use_cassette_test_call_apple, options: { erb: true } }
       ]
 
-      VCR.use_cassettes(cassettes) { }
+      VCR.use_cassettes(cassettes) do
+        expect(VCR).to(
+          have_received(:insert_cassette).with(:use_cassette_test_call_github, {})
+        )
+        expect(VCR).to(
+          have_received(:insert_cassette).with(:use_cassette_test_call_apple, { erb: true })
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
while trying to use `use_cassettes` I found 2 flaws:
1. `option` parameter is required, though it is not documented. if you try to use it without options provided it will crash:
```
VCR.use_cassettes([{ name: 'cassette a' }, { name: 'cassette b' }]) do {} =>

TypeError:
       no implicit conversion of nil into Hash
```

2. options parameter was ignored for the first cassette definition provided

This PR attempts to fix both of these problems