### PR TITLE
CI: Drop removed Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 script: script/ci.sh
 before_install:


### PR DESCRIPTION
Travis made `sudo: false` a no-op a while ago. 

This change drops that directive from the Travis configuration.

[Travis' blog post about when they dropped it](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)