### PR TITLE
Include body.class feedback for non-String body error

### DIFF
--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -62,7 +62,7 @@ module VCR
         super
 
         if body && !body.is_a?(String)
-          raise ArgumentError, "#{self.class} initialized with an invalid body: #{body.inspect}."
+          raise ArgumentError, "#{self.class} initialized with an invalid (non-String) body of class #{body.class}: #{body.inspect}."
         end
 
         # Ensure that the body is a raw string, in case the string instance


### PR DESCRIPTION
A VCR::Request object performs [this following initialization check](https://github.com/vcr/vcr/blob/master/lib/vcr/structs.rb#L64-L66):
```ruby
        if body && !body.is_a?(String)
          raise ArgumentError, "#{self.class} initialized with an invalid body: #{body.inspect}."
        end
```
The error is raised for a non-String body, so it's helpful for the error message to return the _actual_ `body.class` -- but `body.inspect` isn't a robust way to provide that, since _some_ but not _all_ objects include the class in their `.inspect` output.  So this PR explicitly includes `body.class` output.

It also parenthetically mentions "(non-String)" after "invalid", to try to convey the issue is about the class check and not anything with the _content_ of the body, itself.

Resolves #748 