### PR TITLE
Fix broken build due to Hashdiff deprecation warning

### DIFF
--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard"
   spec.add_development_dependency "rack"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "hashdiff", ">= 1.0.0.beta1", "< 2.0.0"
   spec.add_development_dependency "cucumber", "~> 2.0.2"
   spec.add_development_dependency "aruba", "~> 0.5.3"
   spec.add_development_dependency "faraday", "~> 0.11.0"


### PR DESCRIPTION
webmock uses the hashdiff gem, which recently introduced a deprecation warning regarding the spelling of the `Hashdiff` constant.

```
The HashDiff constant used by this gem conflicts with another gem of a similar name.
As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.
```

This warning in the output causes one of the vcr cucumber tests to fail. This is why the master branch currently has a failing Travis build.

The fix is to update to the latest version of the hashdiff gem, which is currently in beta, as suggested here: https://github.com/bblimke/webmock/pull/823#issuecomment-500150597