### PR TITLE
Add single cassette

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -154,7 +154,7 @@ module VCR
         :record, :erb, :match_requests_on, :re_record_interval, :tag, :tags,
         :update_content_length_header, :allow_playback_repeats, :allow_unused_http_interactions,
         :exclusive, :serialize_with, :preserve_exact_body_bytes, :decode_compressed_response,
-        :recompress_response, :persist_with, :clean_outdated_http_interactions
+        :recompress_response, :persist_with, :clean_outdated_http_interactions, :single_cassette
       ]
 
       if invalid_options.size > 0

--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -8,23 +8,25 @@ module VCR
       def configure!
         ::RSpec.configure do |config|
           vcr_cassette_name_for = lambda do |metadata|
-            description = if metadata[:description].empty?
-                            # we have an "it { is_expected.to be something }" block
-                            metadata[:scoped_id]
-                          else
-                            metadata[:description]
-                          end
-            example_group = if metadata.key?(:example_group)
-                              metadata[:example_group]
-                            else
-                              metadata[:parent_example_group]
-                            end
+            descriptions = []
 
-            if example_group
-              [vcr_cassette_name_for[example_group], description].join('/')
-            else
-              description
+            while metadata
+              vcr_options = metadata[:vcr]
+              # without vcr option or just "vcr: true/false"
+              vcr_options = {} unless vcr_options.is_a?(Hash)
+
+              # removes previous descriptions, which are below the context/describe with single cassette
+              descriptions.clear if vcr_options[:single_cassette]
+
+              description = metadata[:description]
+              # without description it is an "it { is_expected.to be something }" block
+              description = metadata[:scoped_id] if description.empty?
+              descriptions.unshift(description)
+
+              metadata = metadata[:example_group] || metadata[:parent_example_group]
             end
+
+            descriptions.join('/')
           end
 
           when_tagged_with_vcr = { :vcr => lambda { |v| !!v } }

--- a/spec/lib/vcr/test_frameworks/rspec_spec.rb
+++ b/spec/lib/vcr/test_frameworks/rspec_spec.rb
@@ -47,4 +47,13 @@ describe VCR::RSpec::Metadata, :skip_vcr_reset do
   it 'allows the cassette options to be set', :vcr => { :match_requests_on => [:method] } do
     expect(VCR.current_cassette.match_requests_on).to eq([:method])
   end
+
+  context 'with single cassette', vcr: { single_cassette: true } do
+    it 'use the same cassette from the context' do
+      expect(VCR.current_cassette.name.split('/')).to eq([
+        'VCR::RSpec::Metadata',
+        'with single cassette'
+      ])
+    end
+  end
 end


### PR DESCRIPTION
The `single_cassette` option makes every test case below the context/describe with this option use the description of this block as cassette name. It has the same behaviour as using cassette_name option in the context/describe, but automatically generating the name.

This PR solves the issue https://github.com/vcr/vcr/issues/700