### PR TITLE
Add record_on_error configuration option

### DIFF
--- a/features/configuration/debug_logging.feature
+++ b/features/configuration/debug_logging.feature
@@ -34,7 +34,7 @@ Feature: Debug Logging
     Given that port numbers in "record.log" are normalized to "7777"
     Then the file "record.log" should contain exactly:
       """
-      [Cassette: 'example'] Initialized with options: {:record=>:once, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system}
+      [Cassette: 'example'] Initialized with options: {:record=>:once, :record_on_error=>true, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system}
       [webmock] Handling request: [get http://localhost:7777/] (disabled: false)
         [Cassette: 'example'] Initialized HTTPInteractionList with request matchers [:method, :host, :path] and 0 interaction(s): {  }
       [webmock] Identified request type (recordable) for [get http://localhost:7777/]
@@ -45,7 +45,7 @@ Feature: Debug Logging
     Given that port numbers in "playback.log" are normalized to "7777"
     Then the file "playback.log" should contain exactly:
       """
-      [Cassette: 'example'] Initialized with options: {:record=>:once, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system}
+      [Cassette: 'example'] Initialized with options: {:record=>:once, :record_on_error=>true, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system}
       [webmock] Handling request: [get http://localhost:7777/] (disabled: false)
         [Cassette: 'example'] Initialized HTTPInteractionList with request matchers [:method, :host, :path] and 1 interaction(s): { [get http://localhost:7777/] => [200 "Hello World"] }
         [Cassette: 'example'] Checking if [get http://localhost:7777/] matches [get http://localhost:7777/] using [:method, :host, :path]

--- a/features/configuration/default_cassette_options.feature
+++ b/features/configuration/default_cassette_options.feature
@@ -70,6 +70,24 @@ Feature: default_cassette_options
     When I run `ruby default_record_mode.rb`
     Then the output should contain "Record mode: :once"
 
+  Scenario: `:record_on_error` defaults to `true` when it has not been set
+    Given a file named "default_record_on_error.rb" with:
+      """ruby
+      require 'vcr'
+
+      VCR.configure do |c|
+        # not important for this example, but must be set to something
+        c.hook_into :webmock
+        c.cassette_library_dir = 'cassettes'
+      end
+
+      VCR.use_cassette('example') do
+        puts "Record on error: #{VCR.current_cassette.record_on_error}"
+      end
+      """
+    When I run `ruby default_record_on_error.rb`
+    Then the output should contain "Record on error: true"
+
   Scenario: cassettes can set their own options
     Given a file named "default_cassette_options.rb" with:
       """ruby

--- a/features/record_modes/record_on_error.feature
+++ b/features/record_modes/record_on_error.feature
@@ -1,0 +1,61 @@
+Feature: :record_on_error
+
+  The `:record_on_error` flag mode will prevent a cassette from being recorded when the code
+  that uses the cassette (a test) raises an error (test failure).
+
+  Background:
+    Given a file named "setup.rb" with:
+      """ruby
+      $server = start_sinatra_app do
+        get('/') { 'Hello' }
+      end
+
+      require 'vcr'
+
+      VCR.configure do |c|
+        c.hook_into                :webmock
+        c.cassette_library_dir     = 'cassettes'
+      end
+      """
+
+  Scenario: Requests are recorded when no error is raised
+    Given a file named "record_when_no_error.rb" with:
+      """ruby
+      require 'setup'
+
+      VCR.use_cassette('example', :record_on_error => false) do
+        response = Net::HTTP.get_response('localhost', '/', $server.port)
+        puts "Response: #{response.body}"
+      end
+      """
+    When I run `ruby record_when_no_error.rb`
+    Then it should pass with "Response: Hello"
+    And the file "cassettes/example.yml" should contain "Hello"
+
+  Scenario: Requests are not recorded when an error is raised and :record_on_error is set to false
+    Given a file named "do_not_record_on_error.rb" with:
+      """ruby
+      require 'setup'
+
+      VCR.use_cassette('example', :record => :once, :record_on_error => false) do
+        Net::HTTP.get_response('localhost', '/', $server.port)
+        raise StandardError, 'The example failed'
+      end
+      """
+    When I run `ruby do_not_record_on_error.rb`
+    Then it should fail with "The example failed"
+    And the file "cassettes/example.yml" should not exist
+
+  Scenario: Requests are recorded when an error is raised and :record_on_error is set to true
+    Given a file named "record_on_error.rb" with:
+      """ruby
+      require 'setup'
+
+      VCR.use_cassette('example', :record => :once, :record_on_error => true) do
+        Net::HTTP.get_response('localhost', '/', $server.port)
+        raise StandardError, 'The example failed'
+      end
+      """
+    When I run `ruby record_on_error.rb`
+    Then it should fail with "The example failed"
+    But the file "cassettes/example.yml" should contain "Hello"

--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -186,6 +186,9 @@ module VCR
 
     begin
       call_block(block, cassette)
+    rescue StandardError
+      cassette.run_failed!
+      raise
     ensure
       eject_cassette
     end

--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -24,6 +24,13 @@ module VCR
     #  plays them back, or does both.
     attr_reader :record_mode
 
+    # @return [Boolean] The cassette's record_on_error mode. When the code that uses the cassette
+    #  raises an error (for example a test failure) and record_on_error is set to false, no
+    #  cassette will be recorded. This is useful when you are TDD'ing an API integration: when
+    #  an error is raised that often means your request is invalid, so you don't want the cassette
+    #  to be recorded.
+    attr_reader :record_on_error
+
     # @return [Array<Symbol, #call>] List of request matchers. Used to find a response from an
     #  existing HTTP interaction to play back.
     attr_reader :match_requests_on
@@ -66,11 +73,26 @@ module VCR
     # @param (see VCR#eject_casssette)
     # @see VCR#eject_cassette
     def eject(options = {})
-      write_recorded_interactions_to_disk
+      write_recorded_interactions_to_disk if should_write_recorded_interactions_to_disk?
 
       if should_assert_no_unused_interactions? && !options[:skip_no_unused_interactions_assertion]
         http_interactions.assert_no_unused_interactions!
       end
+    end
+
+    # @private
+    def run_failed!
+      @run_failed = true
+    end
+
+    # @private
+    def run_failed?
+      @run_failed = false unless defined?(@run_failed)
+      @run_failed
+    end
+
+    def should_write_recorded_interactions_to_disk?
+      !run_failed? || record_on_error
     end
 
     # @private
@@ -151,7 +173,7 @@ module VCR
 
     def assert_valid_options!
       invalid_options = @options.keys - [
-        :record, :erb, :match_requests_on, :re_record_interval, :tag, :tags,
+        :record, :record_on_error, :erb, :match_requests_on, :re_record_interval, :tag, :tags,
         :update_content_length_header, :allow_playback_repeats, :allow_unused_http_interactions,
         :exclusive, :serialize_with, :preserve_exact_body_bytes, :decode_compressed_response,
         :recompress_response, :persist_with, :clean_outdated_http_interactions
@@ -163,7 +185,7 @@ module VCR
     end
 
     def extract_options
-      [:erb, :match_requests_on, :re_record_interval, :clean_outdated_http_interactions,
+      [:record_on_error, :erb, :match_requests_on, :re_record_interval, :clean_outdated_http_interactions,
        :allow_playback_repeats, :allow_unused_http_interactions, :exclusive].each do |name|
         instance_variable_set("@#{name}", @options[name])
       end

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -492,6 +492,7 @@ module VCR
       @rspec_metadata_configured = false
       @default_cassette_options = {
         :record            => :once,
+        :record_on_error   => true,
         :match_requests_on => RequestMatcherRegistry::DEFAULT_MATCHERS,
         :allow_unused_http_interactions => true,
         :serialize_with    => :yaml,

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -572,6 +572,26 @@ describe VCR::Cassette do
       expect(::File).not_to exist(cassette.file)
     end
 
+    context 'when running the wrapped block failed' do
+      context 'when record_on_error is false' do
+        it 'should not record the interactions' do
+          cassette = VCR::Cassette.new('test_cassette', :record_on_error => false)
+          cassette.run_failed!
+
+          expect(cassette.should_write_recorded_interactions_to_disk?).to be false
+        end
+      end
+
+      context 'when record_on_error is true' do
+        it 'should not record the interactions' do
+          cassette = VCR::Cassette.new('test_cassette', :record_on_error => true)
+          cassette.run_failed!
+
+          expect(cassette.should_write_recorded_interactions_to_disk?).to be true
+        end
+      end
+    end
+
     it "writes the recorded interactions to a subdirectory if the cassette name includes a directory" do
       recorded_interactions = [http_interaction { |i| i.response.body = "subdirectory response" }]
       cassette = VCR::Cassette.new('subdirectory/test_cassette')

--- a/spec/lib/vcr/configuration_spec.rb
+++ b/spec/lib/vcr/configuration_spec.rb
@@ -27,6 +27,7 @@ describe VCR::Configuration do
         :match_requests_on => VCR::RequestMatcherRegistry::DEFAULT_MATCHERS,
         :allow_unused_http_interactions => true,
         :record            => :once,
+        :record_on_error   => true,
         :serialize_with    => :yaml,
         :persist_with      => :file_system
       })


### PR DESCRIPTION
When you are TDD'ing an API integration and an error occurs it will
often be caused by an bug in the implementation. In that case no
interactions should be recorded, to avoid having to manually throw away
the cassette every test run until all bugs are solved.

When setting `record_on_error` to false, no interactions will be written
to disk when an error is raised inside the block that uses the cassette.

This change is inspired by [Walkman](https://github.com/derekkraan/walkman), which by default does not record a tape when your test fails.