### PR TITLE
Fix #746: Add drop_unused_requests option to exclude unused interactions

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -176,7 +176,7 @@ module VCR
         :record, :record_on_error, :erb, :match_requests_on, :re_record_interval, :tag, :tags,
         :update_content_length_header, :allow_playback_repeats, :allow_unused_http_interactions,
         :exclusive, :serialize_with, :preserve_exact_body_bytes, :decode_compressed_response,
-        :recompress_response, :persist_with, :clean_outdated_http_interactions
+        :recompress_response, :persist_with, :clean_outdated_http_interactions, :drop_unused_requests
       ]
 
       if invalid_options.size > 0
@@ -186,7 +186,7 @@ module VCR
 
     def extract_options
       [:record_on_error, :erb, :match_requests_on, :re_record_interval, :clean_outdated_http_interactions,
-       :allow_playback_repeats, :allow_unused_http_interactions, :exclusive].each do |name|
+       :allow_playback_repeats, :allow_unused_http_interactions, :exclusive, :drop_unused_requests].each do |name|
         instance_variable_set("@#{name}", @options[name])
       end
 
@@ -259,6 +259,10 @@ module VCR
       record_mode == :all
     end
 
+    def should_remove_unused_interactions?
+      @drop_unused_requests
+    end
+
     def should_assert_no_unused_interactions?
       !(@allow_unused_http_interactions || $!)
     end
@@ -277,7 +281,11 @@ module VCR
         end
       end
 
-      up_to_date_interactions(old_interactions) + new_recorded_interactions
+        if should_remove_unused_interactions?
+          new_recorded_interactions
+        else
+          up_to_date_interactions(old_interactions) + new_recorded_interactions
+        end
     end
 
     def up_to_date_interactions(interactions)

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -604,7 +604,8 @@ describe VCR::Cassette do
 
     [:all, :none, :new_episodes].each do |record_mode|
       context "for a :record => :#{record_mode} cassette with previously recorded interactions" do
-        subject { VCR::Cassette.new('example', :record => record_mode, :match_requests_on => [:uri]) }
+        let(:drop_unused_requests) { false }
+        subject { VCR::Cassette.new('example', :record => record_mode, :match_requests_on => [:uri], drop_unused_requests: drop_unused_requests) }
 
         before(:each) do
           base_dir = "#{VCR::SPEC_ROOT}/fixtures/cassette_spec"
@@ -629,6 +630,7 @@ describe VCR::Cassette do
 
           let(:interaction_foo_1) { interaction("foo 1", :uri => 'http://foo.com/') }
           let(:interaction_foo_2) { interaction("foo 2", :uri => 'http://foo.com/') }
+          let(:unused_request_foo) { interaction("unused foo", :uri => 'http://foo_unused.com/') }
           let(:interaction_bar)   { interaction("bar", :uri => 'http://bar.com/') }
 
           let(:saved_recorded_interactions) { YAML.load_file(subject.file)['http_interactions'].map { |h| VCR::HTTPInteraction.from_hash(h) } }
@@ -636,24 +638,36 @@ describe VCR::Cassette do
 
           before(:each) do
             allow(Time).to receive(:now).and_return(now)
-            allow(subject).to receive(:previously_recorded_interactions).and_return([interaction_foo_1])
+            allow(subject).to receive(:previously_recorded_interactions).and_return([interaction_foo_1,unused_request_foo])
             subject.record_http_interaction(interaction_foo_2)
             subject.record_http_interaction(interaction_bar)
             subject.eject
           end
 
           if record_mode == :all
-            it 'replaces previously recorded interactions with new ones when the requests match' do
-              expect(saved_recorded_interactions.first).to eq(interaction_foo_2)
-              expect(saved_recorded_interactions).not_to include(interaction_foo_1)
+            context "preserves old requests" do
+              it 'only replaces previously recorded interactions with new ones when the requests match' do
+                expect(saved_recorded_interactions).to include(interaction_bar)
+                expect(saved_recorded_interactions).to include(unused_request_foo)
+                expect(saved_recorded_interactions).to include(interaction_foo_2)
+                expect(saved_recorded_interactions).not_to include(interaction_foo_1)
+              end
+
+              it 'appends new recorded interactions that do not match existing ones' do
+                expect(saved_recorded_interactions.last).to eq(interaction_bar)
+              end
+            end
+            context "with drop_unused_requests option added to all" do
+              let(:drop_unused_requests) { true }
+              it "drops unused requests" do
+                expect(saved_recorded_interactions).to match_array([interaction_bar, interaction_foo_2])
+              end
             end
 
-            it 'appends new recorded interactions that do not match existing ones' do
-              expect(saved_recorded_interactions.last).to eq(interaction_bar)
-            end
+
           else
             it 'appends new recorded interactions after existing ones' do
-              expect(saved_recorded_interactions).to eq([interaction_foo_1, interaction_foo_2, interaction_bar])
+              expect(saved_recorded_interactions).to eq([interaction_foo_1, unused_request_foo, interaction_foo_2, interaction_bar])
             end
           end
         end


### PR DESCRIPTION

Address the ability to drop unused requests in cassettes. 



This seemed a better way to address the needs of all vs a whole new recording method.


Fixes #746
