### PR TITLE
Use RSpec metadata value as cassette name if value is String

### DIFF
--- a/lib/vcr/test_frameworks/rspec.rb
+++ b/lib/vcr/test_frameworks/rspec.rb
@@ -32,10 +32,19 @@ module VCR
           config.before(:each, when_tagged_with_vcr) do |ex|
             example = ex.respond_to?(:metadata) ? ex : ex.example
 
+            cassette_name = nil
             options = example.metadata[:vcr]
-            options = options.is_a?(Hash) ? options.dup : {} # in case it's just :vcr => true
+            options = case options
+                      when Hash #=> vcr: { cassette_name: 'foo' }
+                        options.dup
+                      when String #=> vcr: 'bar'
+                        cassette_name = options.dup
+                        {}
+                      else #=> :vcr or vcr: true
+                        {}
+                      end
 
-            cassette_name = options.delete(:cassette_name) ||
+            cassette_name ||= options.delete(:cassette_name) ||
                             vcr_cassette_name_for[example.metadata]
             VCR.insert_cassette(cassette_name, options)
           end

--- a/spec/lib/vcr/test_frameworks/rspec_spec.rb
+++ b/spec/lib/vcr/test_frameworks/rspec_spec.rb
@@ -40,6 +40,18 @@ describe VCR::RSpec::Metadata, :skip_vcr_reset do
     end
   end
 
+  context 'when the metadata value is a string', vcr: 'foo' do
+    it 'uses that string as the cassette name' do
+      expect(VCR.current_cassette.name).to eq('foo')
+    end
+
+    context 'when defined on the example level' do
+      it 'uses that string as the cassette name', vcr: 'bar' do
+        expect(VCR.current_cassette.name).to eq('bar')
+      end
+    end
+  end
+
   it 'allows the cassette name to be overriden', :vcr => { :cassette_name => 'foo' } do
     expect(VCR.current_cassette.name).to eq('foo')
   end


### PR DESCRIPTION
```
describe Foo, vcr: { cassette_name: 'bar' } do
```
could be less verbose. If the metadata value for `vcr` is a String, we should be able to safely use that string as the cassette name:
```
describe Foo, vcr: 'bar' do
```