### PR TITLE
Travis: Avoid update of RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 script: script/ci.sh
 before_install:
-  - gem update --system
   - gem install bundler
 cache: bundler
 rvm:


### PR DESCRIPTION
  - The current RubyGems update process asks for a bundle binary to be installed and Travis CI stalls there, quitting after 10min of inactivity

The solution in this PR is to "not update the RubyGems used".

## Background

This is a new behavior in RubyGems 3.1.0+. 

**Update**: But wait, https://github.com/rubygems/rubygems/pull/3035 is now merged and available, and should be possible to use, now.