### PR TITLE
run structs_spec by itself

### DIFF
--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+require 'spec_helper'
 require 'support/ruby_interpreter'
 
 require 'yaml'

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -1,6 +1,5 @@
 # encoding: UTF-8
 
-require 'spec_helper'
 require 'support/ruby_interpreter'
 
 require 'yaml'

--- a/spec/support/limited_uri.rb
+++ b/spec/support/limited_uri.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 class LimitedURI
   extend Forwardable
 


### PR DESCRIPTION
hi,  I haven't contributed much so please tell me if I'm wrong

I typed this command.

`bundle exec rspec spec/lib/vcr/structs_spec.rb `

Then I got an error like this
```
An error occurred while loading ./spec/lib/vcr/structs_spec.rb.
Failure/Error: extend Forwardable

NameError:
  uninitialized constant LimitedURI::Forwardable
# ./spec/support/limited_uri.rb:2:in `<class:LimitedURI>'
# ./spec/support/limited_uri.rb:1:in `<top (required)>'
# ./spec/lib/vcr/structs_spec.rb:10:in `require'
# ./spec/lib/vcr/structs_spec.rb:10:in `<top (required)>'
No examples found.

Finished in 0.00002 seconds (files took 0.174 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```
So we have to include spec_helper to eliminate this error

Thank you