### PR TITLE
support Faraday persistent connection closing

### DIFF
--- a/lib/vcr/middleware/faraday.rb
+++ b/lib/vcr/middleware/faraday.rb
@@ -31,6 +31,11 @@ module VCR
         RequestHandler.new(@app, env).handle
       end
 
+      # Close any persistent connections.
+      def close
+        @app.close if @app.respond_to?(:close)
+      end
+
       # @private
       class RequestHandler < ::VCR::RequestHandler
         attr_reader :app, :env

--- a/spec/lib/vcr/middleware/faraday_spec.rb
+++ b/spec/lib/vcr/middleware/faraday_spec.rb
@@ -181,4 +181,25 @@ describe VCR::Middleware::Faraday do
       end
     end
   end if defined?(::Typhoeus)
+
+  describe '#close' do
+    let(:faraday_app) { double }
+
+    def close
+      described_class.new(faraday_app).close
+    end
+
+    context 'when adapter supports persistent connections' do
+      it 'calls adapter close method' do
+        expect(faraday_app).to receive(:close)
+        close
+      end
+    end
+
+    context 'when adapter does not support persistent connections' do
+      it 'does not raise error' do
+        expect { close }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Faraday as of `v1.0.0` added a new `close` method (see https://github.com/lostisland/faraday/pull/1069 and https://github.com/lostisland/faraday/pull/1091) that allows to have persistent connections that are closed manually. This PR adds support of this method to `VCR::Middleware::Faraday` by delegating to underlying adapter if adapter supports persistent connections.