### PR TITLE
Use Aruba 0.14.14

### DIFF
--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "hashdiff", ">= 1.0.0.beta1", "< 2.0.0"
   spec.add_development_dependency "cucumber", "~> 2.0.2"
-  spec.add_development_dependency "aruba", "~> 0.14.12"
+  spec.add_development_dependency "aruba", "~> 0.14.14"
   spec.add_development_dependency "faraday", ">= 0.11.0", "< 2.0.0"
   spec.add_development_dependency "httpclient"
   spec.add_development_dependency "excon", "0.62.0"


### PR DESCRIPTION
This PR updates the aruba in use to the latest 0.14 release, which has some fixes for Ruby 2.7.

   - https://github.com/cucumber/aruba/compare/v0.14.12...v0.14.14


Hope this helps! (Narrator: it didn't.)
