### PR TITLE
Add option to downcase cassette names before saving

### DIFF
--- a/features/configuration/debug_logging.feature
+++ b/features/configuration/debug_logging.feature
@@ -34,7 +34,7 @@ Feature: Debug Logging
     Given that port numbers in "record.log" are normalized to "7777"
     Then the file "record.log" should contain exactly:
       """
-      [Cassette: 'example'] Initialized with options: {:record=>:once, :record_on_error=>true, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system}
+      [Cassette: 'example'] Initialized with options: {:record=>:once, :record_on_error=>true, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system, :persister_options=>{}}
       [webmock] Handling request: [get http://localhost:7777/] (disabled: false)
         [Cassette: 'example'] Initialized HTTPInteractionList with request matchers [:method, :host, :path] and 0 interaction(s): {  }
       [webmock] Identified request type (recordable) for [get http://localhost:7777/]
@@ -44,7 +44,7 @@ Feature: Debug Logging
     Given that port numbers in "playback.log" are normalized to "7777"
     Then the file "playback.log" should contain exactly:
       """
-      [Cassette: 'example'] Initialized with options: {:record=>:once, :record_on_error=>true, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system}
+      [Cassette: 'example'] Initialized with options: {:record=>:once, :record_on_error=>true, :match_requests_on=>[:method, :host, :path], :allow_unused_http_interactions=>true, :serialize_with=>:yaml, :persist_with=>:file_system, :persister_options=>{}}
       [webmock] Handling request: [get http://localhost:7777/] (disabled: false)
         [Cassette: 'example'] Initialized HTTPInteractionList with request matchers [:method, :host, :path] and 1 interaction(s): { [get http://localhost:7777/] => [200 "Hello World"] }
         [Cassette: 'example'] Checking if [get http://localhost:7777/] matches [get http://localhost:7777/] using [:method, :host, :path]

--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -108,7 +108,11 @@ module VCR
   #  use. Defaults to :file_system. You can also register and use a
   #  custom persister.
   # @option options :persister_options [Hash] Pass options to the
-  # persister specified in `persist_with`.
+  #  persister specified in `persist_with`. Currently available options for the file_system persister:
+  #    - `:downcase_cassette_names`: when `true`, names of cassettes will be
+  #      normalized in lowercase before reading and writing, which can avoid
+  #      confusion when using both case-sensitive and case-insensitive file
+  #      systems.
   # @option options :preserve_exact_body_bytes [Boolean] Whether or not
   #  to base64 encode the bytes of the requests and responses for this cassette
   #  when serializing it. See also `VCR::Configuration#preserve_exact_body_bytes`.

--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -107,6 +107,8 @@ module VCR
   # @option options :persist_with [Symbol] Which cassette persister to
   #  use. Defaults to :file_system. You can also register and use a
   #  custom persister.
+  # @option options :persister_options [Hash] Pass options to the
+  # persister specified in `persist_with`.
   # @option options :preserve_exact_body_bytes [Boolean] Whether or not
   #  to base64 encode the bytes of the requests and responses for this cassette
   #  when serializing it. See also `VCR::Configuration#preserve_exact_body_bytes`.

--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -176,7 +176,7 @@ module VCR
         :record, :record_on_error, :erb, :match_requests_on, :re_record_interval, :tag, :tags,
         :update_content_length_header, :allow_playback_repeats, :allow_unused_http_interactions,
         :exclusive, :serialize_with, :preserve_exact_body_bytes, :decode_compressed_response,
-        :recompress_response, :persist_with, :clean_outdated_http_interactions
+        :recompress_response, :persist_with, :persister_options, :clean_outdated_http_interactions
       ]
 
       if invalid_options.size > 0

--- a/lib/vcr/cassette/persisters/file_system.rb
+++ b/lib/vcr/cassette/persisters/file_system.rb
@@ -61,8 +61,9 @@ module VCR
         end
 
         def downcase_cassette_names?
-          options = VCR.configuration.default_cassette_options[:persister_options]
-          options && !!options[:downcase_cassette_names]
+          !!VCR.configuration
+            .default_cassette_options
+            .dig(:persister_options, :downcase_cassette_names)
         end
       end
     end

--- a/lib/vcr/cassette/persisters/file_system.rb
+++ b/lib/vcr/cassette/persisters/file_system.rb
@@ -55,7 +55,14 @@ module VCR
             file_extension = '.' + parts.pop
           end
 
-          parts.join('.').gsub(/[^[:word:]\-\/]+/, '_') + file_extension.to_s
+          file_name = parts.join('.').gsub(/[^[:word:]\-\/]+/, '_') + file_extension.to_s
+          file_name.downcase! if downcase_cassette_names?
+          file_name
+        end
+
+        def downcase_cassette_names?
+          options = VCR.configuration.default_cassette_options[:persister_options]
+          options && !!options[:downcase_cassette_names]
         end
       end
     end

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -496,7 +496,8 @@ module VCR
         :match_requests_on => RequestMatcherRegistry::DEFAULT_MATCHERS,
         :allow_unused_http_interactions => true,
         :serialize_with    => :yaml,
-        :persist_with      => :file_system
+        :persist_with      => :file_system,
+        :persister_options => {}
       }
 
       self.uri_parser = URI

--- a/spec/lib/vcr/cassette/persisters/file_system_spec.rb
+++ b/spec/lib/vcr/cassette/persisters/file_system_spec.rb
@@ -64,11 +64,22 @@ module VCR
 
             expected = File.join(FileSystem.storage_location, "\u842c\u570b\u78bc")
             expect(FileSystem.absolute_path_to_file("\u842c\u570b\u78bc")).to eq(expected)
+
+            expected = File.join(FileSystem.storage_location, "Uppercase_Cassette.yml")
+            expect(FileSystem.absolute_path_to_file("Uppercase_Cassette.yml")).to eq(expected)
           end
 
           it 'handles files with no extensions (even when there is a dot in the path)' do
             expected = File.join(FileSystem.storage_location, "/foo_bar/baz_qux")
             expect(FileSystem.absolute_path_to_file("/foo.bar/baz qux")).to eq(expected)
+          end
+
+          it 'downcases cassette names if the option is passed' do
+            VCR.configuration.default_cassette_options.merge!(
+              { :persister_options => { :downcase_cassette_names => true }})
+
+            expected = File.join(FileSystem.storage_location, "/path/to/cassette")
+            expect(FileSystem.absolute_path_to_file("/pAtH/tO/CaSsEtTe")).to eq(expected)
           end
         end
       end

--- a/spec/lib/vcr/cassette/persisters/file_system_spec.rb
+++ b/spec/lib/vcr/cassette/persisters/file_system_spec.rb
@@ -76,7 +76,8 @@ module VCR
 
           it 'downcases cassette names if the option is passed' do
             VCR.configuration.default_cassette_options.merge!(
-              { :persister_options => { :downcase_cassette_names => true }})
+              { :persister_options => { :downcase_cassette_names => true } }
+            )
 
             expected = File.join(FileSystem.storage_location, "/path/to/cassette")
             expect(FileSystem.absolute_path_to_file("/pAtH/tO/CaSsEtTe")).to eq(expected)

--- a/spec/lib/vcr/configuration_spec.rb
+++ b/spec/lib/vcr/configuration_spec.rb
@@ -29,7 +29,8 @@ describe VCR::Configuration do
         :record            => :once,
         :record_on_error   => true,
         :serialize_with    => :yaml,
-        :persist_with      => :file_system
+        :persist_with      => :file_system,
+        :persister_options => {}
       })
     end
 


### PR DESCRIPTION
Hello! 👋 I'd like to propose an option to the default `FileSystem` persister that allows cassette names to be downcased before saving and retrieving, in order to solve case-sensitivity issues between filesystems.

### Background
At Clio, our developers use macOS (which, by default, has a case _insensitive_ filesystem), but we run CI on Linux. We use RSpec, and usually allow VCR to generate cassette names based on the spec descriptions.

We recently had an issue where a cassette had already been generated for a test, but the test's description was modified slightly (i.e. `it "makes an http request"` became `it "makes an HTTP request"`). This passed fine locally, because macOS didn't care about the difference in case, but failed on CI.

### The implementation
I've added a `persister_options` hash to allow custom options to be passed to the persister. I've added an option, `downcase_cassette_names`, to support the feature. (Let me know if you think there could be a better name for this.)

### Usage example
Pass additional configuration to VCR:

```ruby
VCR.configuration do |config|
  ...
    config.default_cassette_options = { 
      persister_options: { downcase_cassette_names: true }
    }
  ...
end
```

### Impact
Since this must be explicitly enabled, it will not cause any breaking changes. However, if it's enabled and users have pre-existing cassettes with uppercase letters, specs may fail on Linux. If users decide to enable this option, they'll have to rename existing cassettes to downcase the names. (this is easier said than done on macOS, so [I wrote a script](https://gist.github.com/mctaylorpants/04ceca3d4d0f7230c191d39e6462b4e5) that gets the job done).


Fixes https://github.com/vcr/vcr/issues/652