### PR TITLE
Make RSpec support --only-failures, --next-failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 
 # Ignores that should be in the global gitignore
 /coverage
+spec/examples.txt

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,7 @@ RSpec.configure do |config|
     $stderr = @orig_std_err
   end
 
+  config.example_status_persistence_file_path = 'spec/examples.txt'
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
   config.order = :random


### PR DESCRIPTION
The [--only-failures](https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures) feature is useful, and maintaining big test suites becomes easier when you can rerun last failed tests easily.

