### PR TITLE
Enable RSpec zero-monkey-patching-mode

### DIFF
--- a/Upgrade.md
+++ b/Upgrade.md
@@ -176,10 +176,10 @@ RSpec.configure do |c|
 end
 
 # apply it to an example group
-describe MyAPIWrapper, :vcr do
+RSpec.describe MyAPIWrapper, :vcr do
 end
 
-describe MyAPIWrapper do
+RSpec.describe MyAPIWrapper do
   # apply it to an individual example
   it "does something", :vcr do
   end

--- a/spec/acceptance/concurrency_spec.rb
+++ b/spec/acceptance/concurrency_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR do
+RSpec.describe VCR do
   def recorded_content_for(name)
     VCR.cassette_persisters[:file_system]["#{name}.yml"].to_s
   end

--- a/spec/acceptance/threading_spec.rb
+++ b/spec/acceptance/threading_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR do
+RSpec.describe VCR do
   context 'when used in a multithreaded environment', :with_monkey_patches => :excon do
     def preload_yaml_serializer_to_avoid_circular_require_warning_race_condition
       VCR.cassette_serializers[:yaml]

--- a/spec/lib/vcr/cassette/erb_renderer_spec.rb
+++ b/spec/lib/vcr/cassette/erb_renderer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR::Cassette::ERBRenderer do
+RSpec.describe VCR::Cassette::ERBRenderer do
   describe '#render' do
     def render(*args)
       described_class.new(*args).render

--- a/spec/lib/vcr/cassette/http_interaction_list_spec.rb
+++ b/spec/lib/vcr/cassette/http_interaction_list_spec.rb
@@ -6,7 +6,7 @@ require 'support/configuration_stubbing'
 
 module VCR
   class Cassette
-    describe HTTPInteractionList do
+    ::RSpec.describe HTTPInteractionList do
       include_context "configuration stubbing"
 
       ::RSpec::Matchers.define :respond_with do |expected|

--- a/spec/lib/vcr/cassette/migrator_spec.rb
+++ b/spec/lib/vcr/cassette/migrator_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'vcr/cassette/migrator'
 require 'yaml'
 
-describe VCR::Cassette::Migrator do
+RSpec.describe VCR::Cassette::Migrator do
   let(:original_contents) { <<-EOF
 ---
 - !ruby/struct:VCR::HTTPInteraction

--- a/spec/lib/vcr/cassette/persisters/file_system_spec.rb
+++ b/spec/lib/vcr/cassette/persisters/file_system_spec.rb
@@ -4,7 +4,7 @@ require 'vcr/cassette/persisters/file_system'
 module VCR
   class Cassette
     class Persisters
-      describe FileSystem do
+      ::RSpec.describe FileSystem do
         before { FileSystem.storage_location = VCR.configuration.cassette_library_dir }
 
         describe "#[]" do

--- a/spec/lib/vcr/cassette/persisters_spec.rb
+++ b/spec/lib/vcr/cassette/persisters_spec.rb
@@ -2,7 +2,7 @@ require 'vcr/cassette/persisters'
 
 module VCR
   class Cassette
-    describe Persisters do
+    ::RSpec.describe Persisters do
       describe "#[]=" do
         context 'when there is already a persister registered for the given name' do
           before(:each) do

--- a/spec/lib/vcr/cassette/serializers_spec.rb
+++ b/spec/lib/vcr/cassette/serializers_spec.rb
@@ -9,7 +9,7 @@ end
 
 module VCR
   class Cassette
-    describe Serializers do
+    ::RSpec.describe Serializers do
       shared_examples_for "encoding error handling" do |name, error_class|
         context "the #{name} serializer" do
           it 'appends info about the :preserve_exact_body_bytes option to the error' do

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR::Cassette do
+RSpec.describe VCR::Cassette do
   def http_interaction
     request = VCR::Request.new(:get)
     response = VCR::Response.new

--- a/spec/lib/vcr/configuration_spec.rb
+++ b/spec/lib/vcr/configuration_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR::Configuration do
+RSpec.describe VCR::Configuration do
   describe '#cassette_library_dir=' do
     let(:tmp_dir) { VCR::SPEC_ROOT + '/../tmp/cassette_library_dir/new_dir' }
     after(:each)  { FileUtils.rm_rf tmp_dir }

--- a/spec/lib/vcr/deprecations_spec.rb
+++ b/spec/lib/vcr/deprecations_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR, 'deprecations', :disable_warnings do
+RSpec.describe VCR, 'deprecations', :disable_warnings do
   describe ".config" do
     it 'delegates to VCR.configure' do
       expect(VCR).to receive(:configure)

--- a/spec/lib/vcr/errors_spec.rb
+++ b/spec/lib/vcr/errors_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module VCR
   module Errors
-    describe UnhandledHTTPRequestError do
+    ::RSpec.describe UnhandledHTTPRequestError do
       def message_for(request_values = {})
         described_class.new(request_with request_values).message
       end

--- a/spec/lib/vcr/library_hooks/excon_spec.rb
+++ b/spec/lib/vcr/library_hooks/excon_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/shared_example_groups/excon'
 
-describe "Excon hook", :with_monkey_patches => :excon do
+RSpec.describe "Excon hook", :with_monkey_patches => :excon do
   after(:each) do
     ::Excon.stubs.clear
     ::Excon.defaults[:mock] = false

--- a/spec/lib/vcr/library_hooks/faraday_spec.rb
+++ b/spec/lib/vcr/library_hooks/faraday_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'vcr/library_hooks/faraday'
 
-describe "Faraday hook" do
+RSpec.describe "Faraday hook" do
   it 'inserts the VCR middleware just before the adapter' do
     conn = Faraday.new(:url => 'http://sushi.com') do |builder|
       builder.request  :url_encoded

--- a/spec/lib/vcr/library_hooks/typhoeus_0.4_spec.rb
+++ b/spec/lib/vcr/library_hooks/typhoeus_0.4_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Typhoeus 0.4 hook", :with_monkey_patches => :typhoeus_0_4 do
+RSpec.describe "Typhoeus 0.4 hook", :with_monkey_patches => :typhoeus_0_4 do
   after(:each) do
     ::Typhoeus::Hydra.clear_stubs
   end

--- a/spec/lib/vcr/library_hooks/typhoeus_spec.rb
+++ b/spec/lib/vcr/library_hooks/typhoeus_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Typhoeus hook", :with_monkey_patches => :typhoeus, :if => (RUBY_INTERPRETER == :mri) do
+RSpec.describe "Typhoeus hook", :with_monkey_patches => :typhoeus, :if => (RUBY_INTERPRETER == :mri) do
   after(:each) do
     ::Typhoeus::Expectation.clear
   end

--- a/spec/lib/vcr/library_hooks/webmock_spec.rb
+++ b/spec/lib/vcr/library_hooks/webmock_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/shared_example_groups/excon'
 
-describe "WebMock hook", :with_monkey_patches => :webmock do
+RSpec.describe "WebMock hook", :with_monkey_patches => :webmock do
   after(:each) do
     ::WebMock.reset!
   end

--- a/spec/lib/vcr/library_hooks_spec.rb
+++ b/spec/lib/vcr/library_hooks_spec.rb
@@ -1,7 +1,7 @@
 require 'vcr/library_hooks'
 
 module VCR
-  describe LibraryHooks do
+  ::RSpec.describe LibraryHooks do
     describe '#disabled?' do
       it 'returns false by default for any argument given' do
         expect(subject.disabled?(:foo)).to be false

--- a/spec/lib/vcr/middleware/faraday_spec.rb
+++ b/spec/lib/vcr/middleware/faraday_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'vcr/library_hooks/faraday'
 
-describe VCR::Middleware::Faraday do
+RSpec.describe VCR::Middleware::Faraday do
   http_libs = %w[ typhoeus net_http patron ]
   http_libs.each do |lib|
     flags = [ :does_not_support_rotating_responses ]

--- a/spec/lib/vcr/middleware/rack_spec.rb
+++ b/spec/lib/vcr/middleware/rack_spec.rb
@@ -3,7 +3,7 @@ require 'vcr/middleware/rack'
 
 module VCR
   module Middleware
-    describe CassetteArguments do
+    ::RSpec.describe CassetteArguments do
       describe '#name' do
         it 'initially returns nil' do
           expect(subject.name).to be_nil
@@ -33,7 +33,7 @@ module VCR
       end
     end
 
-    describe Rack do
+    ::RSpec.describe Rack do
       describe '.new' do
         it 'raises an error if no cassette arguments block is provided' do
           expect {

--- a/spec/lib/vcr/request_ignorer_spec.rb
+++ b/spec/lib/vcr/request_ignorer_spec.rb
@@ -2,7 +2,7 @@ require 'vcr/structs'
 require 'vcr/request_ignorer'
 
 module VCR
-  describe RequestIgnorer do
+  ::RSpec.describe RequestIgnorer do
     def request(uri)
       VCR::Request.new.tap { |r| r.uri = uri }
     end

--- a/spec/lib/vcr/request_matcher_registry_spec.rb
+++ b/spec/lib/vcr/request_matcher_registry_spec.rb
@@ -5,7 +5,7 @@ require 'cgi'
 require 'support/configuration_stubbing'
 
 module VCR
-  describe RequestMatcherRegistry do
+  ::RSpec.describe RequestMatcherRegistry do
     include_context "configuration stubbing"
 
     before do

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -10,7 +10,7 @@ require 'stringio'
 require 'support/limited_uri'
 require 'support/configuration_stubbing'
 
-shared_examples_for "a header normalizer" do
+RSpec.shared_examples_for "a header normalizer" do
   let(:instance) do
     with_headers('Some_Header' => 'value1', 'aNother' => ['a', 'b'], 'third' => [], 'fourth' => nil)
   end
@@ -42,7 +42,7 @@ shared_examples_for "a header normalizer" do
   end
 end
 
-shared_examples_for "a body normalizer" do
+RSpec.shared_examples_for "a body normalizer" do
   it "ensures the body is serialized to yaml as a raw string" do
     body = "My String"
     body.instance_variable_set(:@foo, 7)
@@ -61,7 +61,7 @@ shared_examples_for "a body normalizer" do
 end
 
 module VCR
-  describe HTTPInteraction do
+  ::RSpec.describe HTTPInteraction do
     include_context "configuration stubbing"
     before { allow(config).to receive(:uri_parser) { LimitedURI } }
 
@@ -353,7 +353,7 @@ module VCR
     end
   end
 
-  describe HTTPInteraction::HookAware do
+  ::RSpec.describe HTTPInteraction::HookAware do
     include_context "configuration stubbing"
 
     before do
@@ -440,7 +440,7 @@ module VCR
     end
   end
 
-  describe Request::Typed do
+  ::RSpec.describe Request::Typed do
     [:uri, :method, :headers, :body].each do |method|
       it "delegates ##{method} to the request" do
         request = double(method => "delegated value")
@@ -498,7 +498,7 @@ module VCR
     end
   end
 
-  describe Request do
+  ::RSpec.describe Request do
     include_context "configuration stubbing"
 
     before do
@@ -584,7 +584,7 @@ module VCR
     end
   end
 
-  describe Response do
+  ::RSpec.describe Response do
     it_behaves_like 'a header normalizer' do
       def with_headers(headers)
         described_class.new(:status, headers, nil, '1.1')

--- a/spec/lib/vcr/test_frameworks/cucumber_spec.rb
+++ b/spec/lib/vcr/test_frameworks/cucumber_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR::CucumberTags do
+RSpec.describe VCR::CucumberTags do
   subject { described_class.new(self) }
   let(:before_blocks_for_tags) { {} }
   let(:after_blocks_for_tags) { {} }

--- a/spec/lib/vcr/test_frameworks/rspec_spec.rb
+++ b/spec/lib/vcr/test_frameworks/rspec_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 VCR.configuration.configure_rspec_metadata!
 
-describe VCR::RSpec::Metadata, :skip_vcr_reset do
+RSpec.describe VCR::RSpec::Metadata, :skip_vcr_reset do
   before(:all) { VCR.reset! }
   after(:each) { VCR.reset! }
 

--- a/spec/lib/vcr/util/hooks_spec.rb
+++ b/spec/lib/vcr/util/hooks_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR::Hooks::FilteredHook do
+RSpec.describe VCR::Hooks::FilteredHook do
   describe "#conditionally_invoke" do
     it 'invokes the hook' do
       called = false
@@ -75,7 +75,7 @@ describe VCR::Hooks::FilteredHook do
   end
 end
 
-describe VCR::Hooks do
+RSpec.describe VCR::Hooks do
   let(:hooks_class) { Class.new { include VCR::Hooks } }
 
   subject { hooks_class.new }

--- a/spec/lib/vcr/util/internet_connection_spec.rb
+++ b/spec/lib/vcr/util/internet_connection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR::InternetConnection do
+RSpec.describe VCR::InternetConnection do
   describe '.available?' do
     before(:each) do
       described_class.send(:remove_instance_variable, :@available) if described_class.instance_variable_defined?(:@available)

--- a/spec/lib/vcr/util/version_checker_spec.rb
+++ b/spec/lib/vcr/util/version_checker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module VCR
-  describe VersionChecker do
+  ::RSpec.describe VersionChecker do
     it 'raises an error if the major version is too low' do
       checker = VersionChecker.new('foo', '0.7.3', '1.0.0')
       expect { checker.check_version! }.to raise_error(Errors::LibraryVersionTooLowError)

--- a/spec/lib/vcr/version_spec.rb
+++ b/spec/lib/vcr/version_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "VCR.version" do
+RSpec.describe "VCR.version" do
   subject { VCR.version }
 
   it { should =~ /\A\d+\.\d+\.\d+(\.\w+)?\z/ }

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VCR do
+RSpec.describe VCR do
   def insert_cassette(name = :cassette_test)
     VCR.insert_cassette(name)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ module VCR
 end
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
   tmp_dir = File.expand_path('../../tmp/cassette_library_dir', __FILE__)
   config.before(:each) do |example|
     unless example.metadata[:skip_vcr_reset]

--- a/spec/support/configuration_stubbing.rb
+++ b/spec/support/configuration_stubbing.rb
@@ -1,4 +1,4 @@
-shared_context "configuration stubbing" do
+RSpec.shared_context "configuration stubbing" do
   let(:config) { double("VCR::Configuration") }
 
   before do

--- a/spec/support/shared_example_groups/excon.rb
+++ b/spec/support/shared_example_groups/excon.rb
@@ -1,4 +1,4 @@
-shared_examples "Excon streaming" do
+RSpec.shared_examples "Excon streaming" do
   context "when Excon's streaming API is used" do
     def make_request_to(path)
       chunks = []


### PR DESCRIPTION
This PR enables [RSpec's "zero-monkey-patching mode"](https://relishapp.com/rspec/rspec-core/v/3-9/docs/configuration/zero-monkey-patching-mode).

(Because there exists a VCR::RSpec module, some of the invocations here are _fully qualified_, so that we refer to the right `RSpec`.)