### PR TITLE
Fix tests with excon >= 0.63

### DIFF
--- a/spec/support/http_library_adapters.rb
+++ b/spec/support/http_library_adapters.rb
@@ -227,7 +227,11 @@ HTTP_LIBRARY_ADAPTERS['excon'] = Module.new do
   end
 
   def normalize_request_headers(headers)
-    headers.merge('User-Agent' => [Excon::USER_AGENT])
+    if Excon::VERSION.to_f < 0.63
+      headers.merge('User-Agent' => [Excon::USER_AGENT])
+    else
+      headers.merge('User-Agent' => [Excon::USER_AGENT], 'Accept' => ['*/*'])
+    end
   end
 end
 

--- a/spec/support/http_library_adapters.rb
+++ b/spec/support/http_library_adapters.rb
@@ -227,7 +227,7 @@ HTTP_LIBRARY_ADAPTERS['excon'] = Module.new do
   end
 
   def normalize_request_headers(headers)
-    if Excon::VERSION.start_with?("0.63")
+    if Gem::Version.new(Excon::VERSION) < Gem::Version.new("0.63")
       headers.merge('User-Agent' => [Excon::USER_AGENT])
     else
       headers.merge('User-Agent' => [Excon::USER_AGENT], 'Accept' => ['*/*'])

--- a/spec/support/http_library_adapters.rb
+++ b/spec/support/http_library_adapters.rb
@@ -227,7 +227,7 @@ HTTP_LIBRARY_ADAPTERS['excon'] = Module.new do
   end
 
   def normalize_request_headers(headers)
-    if Excon::VERSION.to_f < 0.63
+    if Excon::VERSION.start_with?("0.63")
       headers.merge('User-Agent' => [Excon::USER_AGENT])
     else
       headers.merge('User-Agent' => [Excon::USER_AGENT], 'Accept' => ['*/*'])


### PR DESCRIPTION
In this version an 'Accept' header has been added in excon [1] and needs to be
added to the default headers to merge too. This should fix #801 and with the
version check being backwards compatible

[1] https://github.com/excon/excon/blame/master/lib/excon/constants.rb#L141