### PR TITLE
Allow Excon >= 0.62.0

### DIFF
--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "aruba", "~> 0.14.14"
   spec.add_development_dependency "faraday", ">= 0.11.0", "< 2.0.0"
   spec.add_development_dependency "httpclient"
-  spec.add_development_dependency "excon", "0.62.0"
+  spec.add_development_dependency "excon", ">= 0.62.0"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "multi_json"
   spec.add_development_dependency "json"


### PR DESCRIPTION
This PR starts allowing Excon **`>= 0.62.0`** instead of `= 0.62.0`.

This is a follow-up from #809 

---

## Background Notes

This PR is a work in progress. The ongoing notes are left here as aide-mémoires.

The current test which fails (intermittently) is 

> rspec ./spec/acceptance/concurrency_spec.rb:15 # VCR when used in a multithreaded environment with an around_http_request can use a cassette in an #around_http_request hook

### the Excon warning `Invalid Excon connection keys: :remote_ip`

`v0.73.0` worked for most of the tests: is this a flake?

```
[excon][WARNING] Invalid Excon connection keys: :remote_ip
```

[excon: search for "remote_ip"](https://github.com/excon/excon/search?q=remote_ip&unscoped_q=remote_ip) -- perhaps something about its mocks?

The `Response` class has a setter and getter for it. Into its `@data` member.
https://github.com/excon/excon/blob/d59f34094e195cae39cd30c019c4130080cb8f4c/lib/excon/response.rb#L41-L46

This `mock.rb`:
https://github.com/excon/excon/blob/v0.73.0/lib/excon/middlewares/mock.rb#L29

**Update**: Attempted a CI retry, by `git commit --amend --no-edit`