### PR TITLE
Remove multi_json dependency, yajl-ruby use only JSON

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,3 @@ platform :mri do
   gem "curb", "~> 0.9.0"
 end
 
-platform :ruby do
-  gem "yajl-ruby"
-end

--- a/features/cassettes/format.feature
+++ b/features/cassettes/format.feature
@@ -35,8 +35,8 @@ Feature: Cassette format
       (such as on ruby 1.8), to ensure that syck is always used.
     - `:psych`--Uses psych (the new ruby 1.9 YAML engine). This is useful when
       you want to ensure that psych is always used.
-    - `:json`--Uses [multi_json](https://github.com/intridea/multi_json)
-      to serialize the cassette data as JSON.
+    - `:json`--Uses Ruby's standard library to serialize the cassette data as
+      JSON.
     - `:compressed`--Wraps the default YAML serializer with Zlib, writing
       compressed cassettes to disk.
 

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -1,5 +1,4 @@
 require 'vcr'
-require 'multi_json'
 
 module VCRHelpers
 
@@ -140,8 +139,8 @@ end
 
 Then(/^the file "([^"]*)" should contain JSON like:$/) do |file_name, expected_content|
   actual_content = cd('.') { File.read(file_name) }
-  actual = MultiJson.decode(actual_content)
-  expected = MultiJson.decode(expected_content.to_s)
+  actual = JSON.parse(actual_content)
+  expected = JSON.parse(expected_content.to_s)
   expect(normalize_cassette_hash(actual)).to eq(normalize_cassette_hash(expected))
 end
 

--- a/lib/vcr/cassette/serializers/json.rb
+++ b/lib/vcr/cassette/serializers/json.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 
 module VCR
   class Cassette
@@ -13,8 +13,8 @@ module VCR
         extend EncodingErrorHandling
 
         # @private
-        ENCODING_ERRORS = [MultiJson::DecodeError, ArgumentError]
-        ENCODING_ERRORS << EncodingError if defined?(EncodingError)
+        ENCODING_ERRORS = [ArgumentError]
+        ENCODING_ERRORS << ::JSON::GeneratorError
 
         # The file extension to use for this serializer.
         #
@@ -23,23 +23,23 @@ module VCR
           "json"
         end
 
-        # Serializes the given hash using `MultiJson`.
+        # Serializes the given hash using `JSON`.
         #
         # @param [Hash] hash the object to serialize
         # @return [String] the JSON string
         def serialize(hash)
           handle_encoding_errors do
-            MultiJson.encode(hash)
+            ::JSON.generate(hash)
           end
         end
 
-        # Deserializes the given string using `MultiJson`.
+        # Deserializes the given string using `JSON`.
         #
         # @param [String] string the JSON string
         # @return [Hash] the deserialized object
         def deserialize(string)
           handle_encoding_errors do
-            MultiJson.decode(string)
+            ::JSON.parse(string)
           end
         end
       end

--- a/spec/lib/vcr/cassette/serializers_spec.rb
+++ b/spec/lib/vcr/cassette/serializers_spec.rb
@@ -1,6 +1,6 @@
 require 'support/ruby_interpreter'
 require 'vcr/cassette/serializers'
-require 'multi_json'
+require 'json'
 
 begin
   require 'psych' # ensure psych is loaded for these tests if its available
@@ -73,21 +73,8 @@ module VCR
       end
 
       it_behaves_like "a serializer", :json,  "json", :lazily_loaded do
-        engines = {}
-
-        if RUBY_INTERPRETER == :jruby
-          # don't test yajl on jruby
-        else
-          engines[:yajl] = MultiJson::LoadError
-        end
-
-        engines.each do |engine, error|
-          context "when MultiJson is configured to use #{engine.inspect}", :unless => (RUBY_INTERPRETER == :jruby) do
-            before { MultiJson.engine = engine }
-            it_behaves_like "encoding error handling", :json, error do
-              let(:string) { "\xFA" }
-            end
-          end
+        it_behaves_like "encoding error handling", :json, ::JSON::GeneratorError do
+          let(:string) { "\xFA" }
         end
       end
 

--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "httpclient"
   spec.add_development_dependency "excon", ">= 0.62.0"
   spec.add_development_dependency "timecop"
-  spec.add_development_dependency "multi_json"
   spec.add_development_dependency "json"
   spec.add_development_dependency "relish"
   spec.add_development_dependency "mime-types"


### PR DESCRIPTION
This ~is a WIP PR to explore~ does "stop using `multi_json`" as described in #789.

Fixes #789

## Steps

- remove the dependency
- find errors in breaking tests
- also, remove the now-unused yajl-ruby from the `Gemfile`