### PR TITLE
Release 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## 6.0.0 (May 28, 2020)
+[Full Changelog](https://github.com/vcr/vcr/compare/v5.1.0...v6.0.0)
+
+- [breaking] Require Ruby 2.3 or newer (#816)
+- [new] Add option to downcase cassette names before saving (#802)
+- [patch] Fix: Prevent storing empty `http_version` on cassettes (#709)
+- [patch] Support Faraday persistent connection closing (#793)
+- [patch] Support Faraday 1.0 (#794)
+- Remove `multi_json` dependency, `yajl-ruby` and use only JSON (#815)
+
 ## 5.1.0 (Feb 5, 2020)
 [Full Changelog](https://github.com/vcr/vcr/compare/v5.0.0...v5.1.0)
   - Use RSpec metadata value as cassette name if value is String (#774)

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ VCR follows the principles of [semantic versioning](https://semver.org/). The [A
 
 **Ruby Interpreter Compatibility**
 
-VCR versions 5.x are tested on the following ruby interpreters:
+VCR versions 6.x are tested on the following ruby interpreters:
 
   * MRI 2.4
   * MRI 2.5
   * MRI 2.6
 
-Note that as of VCR 3, 1.8.7 and 1.9.2 are explicitly not supported.
+Note that as of VCR 6, only 2.3+ is explicitly supported.
 
 **Development**
 

--- a/lib/vcr/version.rb
+++ b/lib/vcr/version.rb
@@ -10,7 +10,7 @@ module VCR
   #   * `parts` [Array<Integer>] List of the version parts.
   def version
     @version ||= begin
-      string = '5.1.0'
+      string = '6.0.0'
 
       def string.parts
         split('.').map { |p| p.to_i }


### PR DESCRIPTION
This PR contains **version bump** and a **changelog** summary (left out non-essential changes) and **a README note change**.

Please do take a look at it, see if it looks clear enough.