### PR TITLE
Mention explicit about ruby 2.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 - [patch] Fix: Prevent storing empty `http_version` on cassettes (#709)
 - [patch] Support Faraday persistent connection closing (#793)
 - [patch] Support Faraday 1.0 (#794)
+- Support ruby 2.7 in test matrix
 - Remove `multi_json` dependency, `yajl-ruby` and use only JSON (#815)
 
 ## 5.1.0 (Feb 5, 2020)

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ VCR versions 6.x are tested on the following ruby interpreters:
   * MRI 2.4
   * MRI 2.5
   * MRI 2.6
+  * MRI 2.7
 
-Note that as of VCR 6, only 2.3+ is explicitly supported.
+Note that as of VCR 6, only >= 2.4 is explicitly supported.
 
 **Development**
 


### PR DESCRIPTION
Add missing info in changelog and readme about 2.7 support

https://github.com/vcr/vcr/pull/816#issuecomment-636000439

here you are small PR @olleolleolle 