### PR TITLE
Fix: the behavior of the option re_record_interval "none"

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -192,10 +192,9 @@ module VCR
 
       assign_tags
 
-      @record_mode = @options[:record]
       @serializer  = VCR.cassette_serializers[@options[:serialize_with]]
       @persister   = VCR.cassette_persisters[@options[:persist_with]]
-      @record_mode = :all if should_re_record?
+      @record_mode = should_re_record?(@options[:record]) ? :all : @options[:record]
       @parent_list = @exclusive ? HTTPInteractionList::NullList : VCR.http_interactions
     end
 
@@ -231,9 +230,10 @@ module VCR
       end
     end
 
-    def should_re_record?
+    def should_re_record?(record_mode)
       return false unless @re_record_interval
       return false unless originally_recorded_at
+      return false if record_mode == :none
 
       now = Time.now
 

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -320,9 +320,16 @@ RSpec.describe VCR::Cassette do
                   Time.now - 5.days - 60
                 ] end
 
-                it "has :all for the record mode when there is an internet connection available" do
-                  allow(VCR::InternetConnection).to receive(:available?).and_return(true)
-                  expect(subject.record_mode).to eq(:all)
+                if record_mode == :none
+                  it "has :none for the record mode when there is an internet connection available" do
+                    allow(VCR::InternetConnection).to receive(:available?).and_return(true)
+                    expect(subject.record_mode).to eq(:none)
+                  end
+                else
+                  it "has :all for the record mode when there is an internet connection available" do
+                    allow(VCR::InternetConnection).to receive(:available?).and_return(true)
+                    expect(subject.record_mode).to eq(:all)
+                  end
                 end
 
                 it "has :#{record_mode} for the record mode when there is no internet connection available" do


### PR DESCRIPTION
In this pull request, we are changing how the option `re_record_interval` behaves.

If this option is provided together with `record` mode set to `none`, VCR won't re-record cassettes, even if their intervals have expired.

This commit solves the issue #687 