### PR TITLE
Fix compatibility with frozen string literals

### DIFF
--- a/lib/vcr/version.rb
+++ b/lib/vcr/version.rb
@@ -10,7 +10,7 @@ module VCR
   #   * `parts` [Array<Integer>] List of the version parts.
   def version
     @version ||= begin
-      string = '6.0.0'
+      string = +'6.0.0'
 
       def string.parts
         split('.').map { |p| p.to_i }
@@ -28,7 +28,7 @@ module VCR
         parts[2]
       end
 
-      string
+      string.freeze
     end
   end
 end


### PR DESCRIPTION
We're running one of our app's CI with `RUBYOPT="--enable-frozen-string-literal"`, and VCR fails with:

```
TypeError: can't define singleton
gems/vcr-3.0.3/lib/vcr/version.rb:15:in `version'
gems/vcr-3.0.3/lib/vcr/errors.rb:78:in `relish_version_slug'
```

