### PR TITLE
Transforms ERB hash keys to symbol, in case string

### DIFF
--- a/lib/vcr/cassette/erb_renderer.rb
+++ b/lib/vcr/cassette/erb_renderer.rb
@@ -40,8 +40,9 @@ module VCR
       end
 
       @@struct_cache = Hash.new do |hash, attributes|
-        attributes.map!(&:to_sym)
-        hash[attributes] = Struct.new(*attributes)
+        attributes = attributes.map(&:to_sym)
+        hash[attributes] = Struct.new(*attributes) unless hash.key?(attributes)
+        hash[attributes]
       end
 
       def variables_object

--- a/lib/vcr/cassette/erb_renderer.rb
+++ b/lib/vcr/cassette/erb_renderer.rb
@@ -40,6 +40,7 @@ module VCR
       end
 
       @@struct_cache = Hash.new do |hash, attributes|
+        attributes.map!(&:to_sym)
         hash[attributes] = Struct.new(*attributes)
       end
 

--- a/spec/lib/vcr/cassette/erb_renderer_spec.rb
+++ b/spec/lib/vcr/cassette/erb_renderer_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe VCR::Cassette::ERBRenderer do
         expect(render(vars_content, 'var1' => 'foo', 'var2' => 'bar')).to eq('foo. ERB with Vars! bar')
       end
 
+      it 'reuses the struct cache for similar sets of symbol and string variable names' do
+        cache = described_class.class_variable_get('@@struct_cache')
+        expect( cache[[:var1, :var2]].object_id ).to eq cache[['var1', 'var2']].object_id
+      end
+
       it 'raises an appropriate error when one or more of the needed variables are not passed' do
         expect {
           render(vars_content, { :var1 => 'foo' }, "vars")

--- a/spec/lib/vcr/cassette/erb_renderer_spec.rb
+++ b/spec/lib/vcr/cassette/erb_renderer_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe VCR::Cassette::ERBRenderer do
         expect(render(vars_content, :var1 => 'foo', :var2 => 'bar')).to eq('foo. ERB with Vars! bar')
       end
 
+      it 'renders the file content as ERB with the passed variables having string keys' do
+        expect(render(vars_content, 'var1' => 'foo', 'var2' => 'bar')).to eq('foo. ERB with Vars! bar')
+      end
+
       it 'raises an appropriate error when one or more of the needed variables are not passed' do
         expect {
           render(vars_content, { :var1 => 'foo' }, "vars")


### PR DESCRIPTION
Passing an ERB hash with string keys was causing a NameError in
struct cache initialization, as Struct members must be symbols.
The NameError was being rescued and re-raised, saying the cassette
"references undefined variable", which was misleading.