### PR TITLE
add VCR.turned_on

### DIFF
--- a/features/cassettes/no_cassette.feature
+++ b/features/cassettes/no_cassette.feature
@@ -52,7 +52,7 @@ Feature: Error for HTTP request made when no cassette is in use
       | c.hook_into :excon    | excon                 |
       | c.hook_into :faraday  | faraday (w/ net_http) |
 
-  Scenario: Temporarily turn VCR off to allow HTTP requests to procede as normal
+  Scenario: Temporarily turn VCR off to allow HTTP requests to proceed as normal
     Given a file named "turn_off_vcr.rb" with:
       """ruby
       $server = start_sinatra_app do
@@ -82,6 +82,10 @@ Feature: Error for HTTP request made when no cassette is in use
       VCR.turn_off!
       make_request "After calling VCR.turn_off!"
 
+      VCR.turned_on do
+        make_request "In VCR.turned_on block"
+      end
+
       VCR.turn_on!
       make_request "After calling VCR.turn_on!"
       """
@@ -100,6 +104,11 @@ Feature: Error for HTTP request made when no cassette is in use
       """
       After calling VCR.turn_off!
       Hello
+      """
+    And the output should contain:
+      """
+      In VCR.turned_on block
+      Error: VCR::Errors::UnhandledHTTPRequestError
       """
     And the output should contain:
       """

--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -266,6 +266,7 @@ module VCR
   # @see #turn_off!
   # @see #turn_on!
   # @see #turned_on?
+  # @see #turned_on
   def turned_off(options = {})
     turn_off!(options)
 
@@ -301,11 +302,28 @@ module VCR
     set_context_value(:turned_off, true)
   end
 
+  # Turns on VCR, for the duration of a block.
+  # @param (see #turn_off!)
+  # @return [void]
+  # @see #turn_off!
+  # @see #turned_off
+  # @see #turned_on?
+  def turned_on(options = {})
+    turn_on!
+
+    begin
+      yield
+    ensure
+      turn_off!(options)
+    end
+  end
+
   # Turns on VCR, if it has previously been turned off.
   # @return [void]
   # @see #turn_off!
   # @see #turned_off
   # @see #turned_on?
+  # @see #turned_on
   def turn_on!
     set_context_value(:turned_off, false)
   end

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -346,6 +346,27 @@ RSpec.describe VCR do
     end
   end
 
+  describe '.turned_on' do
+    before { VCR.turn_off! }
+    it 'yields with VCR turned on' do
+      expect(VCR).not_to be_turned_on
+      yielded = false
+
+      VCR.turned_on do
+        yielded = true
+        expect(VCR).to be_turned_on
+      end
+
+      expect(yielded).to eq(true)
+      expect(VCR).not_to be_turned_on
+    end
+
+    it 'passes options through to .turn_off!' do
+      expect(VCR).to receive(:turn_off!).with(:ignore_cassettes => true)
+      VCR.turned_on(:ignore_cassettes => true) { }
+    end
+  end
+
   describe '.turned_on?' do
     it 'is on by default' do
       expect(VCR).to be_turned_on


### PR DESCRIPTION
Regarding #834 this provides the method `VCR.turned_on` similar to `VCR.turned_off`