### PR TITLE
Update docs to warn of a possible gotcha

### DIFF
--- a/features/configuration/filter_sensitive_data.feature
+++ b/features/configuration/filter_sensitive_data.feature
@@ -26,8 +26,11 @@ Feature: Filter sensitive data
 
   Warning, the data you're filtering may have been escaped or encoded.
   Thus you may need to escape the sensitive text. For example, if
-  "some&password" is in your cassette, you will need to filter
-  "some&amp;password". You can also use `CGI::escapeHTML('some&password')`.
+  "some&password" is in your cassette within a context which is html
+  escaped, you will need to filter "some&amp;password" or
+  `CGI::escapeHTML('some&password')`. Similarly if it's escaped in a
+  query string, then you will need to filter "some%26password"
+  or `CGI::escape('some&password')`
 
   You can specify as many filterings as you want.
 

--- a/features/configuration/filter_sensitive_data.feature
+++ b/features/configuration/filter_sensitive_data.feature
@@ -24,6 +24,11 @@ Feature: Filter sensitive data
   substitution string so that the interaction will be identical to what was
   originally recorded.
 
+  Warning, the data you're filtering, may have be escaped or encoded.
+  Thus you may need to escape the sensitive text. For example if
+  "some&password" is in your cassette you will need to filter
+  "some&amp;password". You may wish to use `CGI::escapeHTML('some&password')`.
+
   You can specify as many filterings as you want.
 
   Scenario: Multiple filterings

--- a/features/configuration/filter_sensitive_data.feature
+++ b/features/configuration/filter_sensitive_data.feature
@@ -24,10 +24,10 @@ Feature: Filter sensitive data
   substitution string so that the interaction will be identical to what was
   originally recorded.
 
-  Warning, the data you're filtering, may have be escaped or encoded.
-  Thus you may need to escape the sensitive text. For example if
-  "some&password" is in your cassette you will need to filter
-  "some&amp;password". You may wish to use `CGI::escapeHTML('some&password')`.
+  Warning, the data you're filtering may have been escaped or encoded.
+  Thus you may need to escape the sensitive text. For example, if
+  "some&password" is in your cassette, you will need to filter
+  "some&amp;password". You can also use `CGI::escapeHTML('some&password')`.
 
   You can specify as many filterings as you want.
 


### PR DESCRIPTION
`filter_sensitive_data` may silently ignore replacing
the intended text if it has been encoded.

fixes #717 