### PR TITLE
Generate pretty-formatted JSON cassettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## Unreleased changes
 
-- JSON-serializer generates formatted output.
+- [breaking] JSON-serializer generates pretty-formatted output.
 - [new] Add `VCR.turned_on` similar to `VCR.turned_off` (#681)
 - [fix] cassettes will match URIs with trailing dot. eg `example.com.` (#834)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ## Unreleased changes
 
+- JSON-serializer generates formatted output.
 - [new] Add `VCR.turned_on` similar to `VCR.turned_off` (#681)
 - [fix] cassettes will match URIs with trailing dot. eg `example.com.` (#834)
 

--- a/features/configuration/preserve_exact_body_bytes.feature
+++ b/features/configuration/preserve_exact_body_bytes.feature
@@ -65,7 +65,10 @@ Feature: Preserve Exact Body Bytes
       """
     And the file "cassettes/example.json" should contain:
       """
-      "body":{"encoding":"ASCII-8BIT","base64_string":"YWJjIPo=\n"}
+              "body": {
+                "encoding": "ASCII-8BIT",
+                "base64_string": "YWJjIPo=\n"
+              }
       """
 
   Scenario: Preserve exact bytes for cassette with `:preserve_exact_body_bytes` option
@@ -99,10 +102,16 @@ Feature: Preserve Exact Body Bytes
     When I run `ruby preserve.rb`
     Then the file "cassettes/preserve_bytes.json" should contain:
       """
-      "body":{"encoding":"US-ASCII","base64_string":"SGVsbG8gV29ybGQ=\n"}
+              "body": {
+                "encoding": "US-ASCII",
+                "base64_string": "SGVsbG8gV29ybGQ=\n"
+              }
       """
      And the file "cassettes/dont_preserve_bytes.json" should contain:
       """
-      "body":{"encoding":"US-ASCII","string":"Hello World"}
+              "body": {
+                "encoding": "US-ASCII",
+                "string": "Hello World"
+              }
       """
 

--- a/lib/vcr/cassette/serializers/json.rb
+++ b/lib/vcr/cassette/serializers/json.rb
@@ -3,7 +3,7 @@ require 'json'
 module VCR
   class Cassette
     class Serializers
-      # The JSON serializer. Uses `MultiJson` under the covers.
+      # The JSON serializer.
       #
       # @see Psych
       # @see Syck
@@ -29,7 +29,7 @@ module VCR
         # @return [String] the JSON string
         def serialize(hash)
           handle_encoding_errors do
-            ::JSON.generate(hash)
+            ::JSON.pretty_generate(hash)
           end
         end
 

--- a/lib/vcr/cassette/serializers/json.rb
+++ b/lib/vcr/cassette/serializers/json.rb
@@ -3,7 +3,7 @@ require 'json'
 module VCR
   class Cassette
     class Serializers
-      # The JSON serializer.
+      # The JSON serializer. Uses `MultiJson` under the covers.
       #
       # @see Psych
       # @see Syck

--- a/spec/lib/vcr/cassette/serializers_spec.rb
+++ b/spec/lib/vcr/cassette/serializers_spec.rb
@@ -150,4 +150,3 @@ module VCR
     end
   end
 end
-


### PR DESCRIPTION
YAML-serializer produces pretty-formatted output. And I think it is more useful/human-readable/understandable.
So I would like to mirror this behaviour in JSON-serializer.

As I see there is another option which will not change current behaviour of JSON-serializer - make a separate serializer which will make a pretty-formatted output (e.g. `Serializers::PrettyJSON`).