### PR TITLE
Support Cucumber-Ruby v4 and later

### DIFF
--- a/lib/vcr/test_frameworks/cucumber.rb
+++ b/lib/vcr/test_frameworks/cucumber.rb
@@ -47,9 +47,20 @@ module VCR
                 scenario.scenario_outline.name,
                 scenario.name.split("\n").first
               ].join("/")
-            else
+            elsif scenario.respond_to?(:feature)
               [ scenario.feature.name.split("\n").first,
                 scenario.name.split("\n").first
+              ].join("/")
+            elsif scenario.location.lines.min == scenario.location.lines.max
+              # test case from a regular scenario in cucumber version 4
+              [ scenario.location.file.split("/").last.split(".").first,
+                scenario.name.split("\n").first
+              ].join("/")
+            else
+              # test case from a scenario with examples ("scenario outline") in cucumber version 4
+              [ scenario.location.file.split("/").last.split(".").first,
+                scenario.name.split("\n").first,
+                "Example at line #{scenario.location.lines.max}"
               ].join("/")
             end
           else


### PR DESCRIPTION
In version 4 of Cucumber-Ruby the execution of test cases is based on Pickles. Therefore less data from the feature files are available to the before/after/etc hooks. Also the Gherkin grammar has changed so that (all) Scenarios can have Examples - that is "Scenario Outline" is not just synonym for "Scenario".

Therefore, in case of the "use scenario name" option, use the feature file name instead of feature name, and use the row of the example to create uniqueness for Scenarios with Examples.

Fixes #843.
