### PR TITLE
Add :clean record mode for cleaning unused HTTP interactions from cassettes

### DIFF
--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -265,7 +265,7 @@ module VCR
     end
 
     def should_assert_no_unused_interactions?
-      !should_clean_unused_interactions? && !(@allow_unused_http_interactions || $!)
+      !(@allow_unused_http_interactions || $!)
     end
 
     def raw_cassette_bytes


### PR DESCRIPTION
Adds a new record mode :clean to actively check for unused HTTP interactions and automatically removes them from existing cassettes.
This helps reduce cassette file size as well as provide a clear picture of actual requests being made for a cassette.

### Caveats
- Clears unused HTTP interactions in a cassette file. This may have unintended consequences for cassette files used by a number of different examples but only use a subset of the HTTP interactions.

### Additional Notes
- This feature works similarly to the configuration option `clean_outdated_http_interactions` however that requires `re_record_interval` which will have the result of clearing used http interactions that might be old but still valid.