### PR TITLE
Add localhost_ignored? to request_ignorer

### DIFF
--- a/lib/vcr/request_ignorer.rb
+++ b/lib/vcr/request_ignorer.rb
@@ -25,6 +25,10 @@ module VCR
       end
     end
 
+    def localhost_ignored?
+      (LOCALHOST_ALIASES & ignore_hosts.to_a).any?
+    end
+
     def ignore_hosts(*hosts)
       ignored_hosts.merge(hosts)
     end

--- a/spec/lib/vcr/request_ignorer_spec.rb
+++ b/spec/lib/vcr/request_ignorer_spec.rb
@@ -62,7 +62,7 @@ module VCR
     end
 
     context 'when ignore_localhost is set to false' do
-      before(:each) { subject.ignore_localhost = false }
+      before { subject.ignore_localhost = false }
 
       it 'localhost_ignored is false' do
         expect(subject.localhost_ignored?).to eq(false)

--- a/spec/lib/vcr/request_ignorer_spec.rb
+++ b/spec/lib/vcr/request_ignorer_spec.rb
@@ -55,6 +55,18 @@ module VCR
       RequestIgnorer::LOCALHOST_ALIASES.each do |host|
         it_behaves_like "#ignore?", "http://#{host}/foo", true
       end
+
+      it 'localhost_ignored is true' do
+        expect(subject.localhost_ignored?).to eq(true)
+      end
+    end
+
+    context 'when ignore_localhost is set to false' do
+      before(:each) { subject.ignore_localhost = false }
+
+      it 'localhost_ignored is false' do
+        expect(subject.localhost_ignored?).to eq(false)
+      end
     end
 
     context 'when ignore_localhost is not set' do


### PR DESCRIPTION
In our setup, we want to use VCR in a helper, which needs to ignore localhost. At the end of the helper, we want to unignore localhost, but only if VCR was not configured to ignore localhost before. 

```rb
module SomeHelper
    def action
        with_vcr do 
            call
        end
    end

    private

    def with_vcr(&block)
        localhost_already_ignored = VCR.request_ignorer.localhost_ignored?
        VCR.request_ignorer.ignore_localhost = true unless localhost_already_ignored

        VCR.use_cassette("helper_cassette") { yield block }
        VCR.request_ignorer.ignore_localhost = false unless localhost_already_ignored
    end
end
```

This PR adds the method `localhost_ignored?`. 