### PR TITLE
Handle `use_cassette(..., erb: {})`

### DIFF
--- a/lib/vcr/cassette/erb_renderer.rb
+++ b/lib/vcr/cassette/erb_renderer.rb
@@ -32,7 +32,7 @@ module VCR
       end
 
       def erb_variables
-        @erb if @erb.is_a?(Hash)
+        @erb if @erb.is_a?(Hash) && !@erb.empty?
       end
 
       def template

--- a/spec/lib/vcr/cassette/erb_renderer_spec.rb
+++ b/spec/lib/vcr/cassette/erb_renderer_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe VCR::Cassette::ERBRenderer do
       it 'gracefully handles the template being nil' do
         expect(render(nil, true)).to be_nil
       end
+
+      it 'gracefully handles being passed {} instead of true' do
+        expect(render(no_vars_content, {})).to eq("7. Some ERB")
+      end
     end
 
     context 'when ERB is enabled and variables are passed' do


### PR DESCRIPTION
Prior to this change, attemptying to pass an empty hash would result in an `ArgumentError` in the VCR ERB renderer internals:

     Failure/Error: hash[attributes] = Struct.new(*attributes) unless hash.key?(attributes)

     ArgumentError:
       wrong number of arguments (given 0, expected 1+)
     # ./lib/vcr/cassette/erb_renderer.rb:44:in `new'
     ...

An empty hash is still "true" in Ruby, and should be usable to denote wanting ERB to evaluate, but no local variables be defined.

I did not bother updating `features/cassettes/dynamic_erb.feature`, as this feels more like something that should unsurprisingly work, as opposed to a feature needing documentation. Glad to update it if it's decided it is warranted.