### PR TITLE
Improve error message for syntax error in cassette

### DIFF
--- a/lib/vcr/cassette/serializers.rb
+++ b/lib/vcr/cassette/serializers.rb
@@ -54,6 +54,16 @@ module VCR
         raise
       end
     end
+
+    # @private
+    module SyntaxErrorHandling
+      def handle_syntax_errors
+        yield
+      rescue *self::SYNTAX_ERRORS => e
+        e.message << "\nNote: This is a VCR cassette. If it is using ERB, you may have forgotten to pass the `:erb` option to `use_cassette`."
+        raise
+      end
+    end
   end
 end
 

--- a/lib/vcr/cassette/serializers/json.rb
+++ b/lib/vcr/cassette/serializers/json.rb
@@ -11,10 +11,14 @@ module VCR
       module JSON
         extend self
         extend EncodingErrorHandling
+        extend SyntaxErrorHandling
 
         # @private
         ENCODING_ERRORS = [ArgumentError]
         ENCODING_ERRORS << ::JSON::GeneratorError
+
+        # @private
+        SYNTAX_ERRORS = [::JSON::ParserError]
 
         # The file extension to use for this serializer.
         #
@@ -39,7 +43,9 @@ module VCR
         # @return [Hash] the deserialized object
         def deserialize(string)
           handle_encoding_errors do
-            ::JSON.parse(string)
+            handle_syntax_errors do
+              ::JSON.parse(string)
+            end
           end
         end
       end

--- a/lib/vcr/cassette/serializers/psych.rb
+++ b/lib/vcr/cassette/serializers/psych.rb
@@ -11,9 +11,13 @@ module VCR
       module Psych
         extend self
         extend EncodingErrorHandling
+        extend SyntaxErrorHandling
 
         # @private
         ENCODING_ERRORS = [ArgumentError]
+
+        # @private
+        SYNTAX_ERRORS = [::Psych::SyntaxError]
 
         # The file extension to use for this serializer.
         #
@@ -40,7 +44,9 @@ module VCR
         # @return [Hash] the deserialized object
         def deserialize(string)
           handle_encoding_errors do
-            ::Psych.load(string)
+            handle_syntax_errors do
+              ::Psych.load(string)
+            end
           end
         end
       end

--- a/lib/vcr/cassette/serializers/syck.rb
+++ b/lib/vcr/cassette/serializers/syck.rb
@@ -11,9 +11,13 @@ module VCR
       module Syck
         extend self
         extend EncodingErrorHandling
+        extend SyntaxErrorHandling
 
         # @private
         ENCODING_ERRORS = [ArgumentError]
+
+        # @private
+        SYNTAX_ERRORS = [::Psych::SyntaxError]
 
         # The file extension to use for this serializer.
         #
@@ -38,7 +42,9 @@ module VCR
         # @return [Hash] the deserialized object
         def deserialize(string)
           handle_encoding_errors do
-            using_syck { ::YAML.load(string) }
+            handle_syntax_errors do
+              using_syck { ::YAML.load(string) }
+            end
           end
         end
 

--- a/lib/vcr/cassette/serializers/yaml.rb
+++ b/lib/vcr/cassette/serializers/yaml.rb
@@ -13,9 +13,13 @@ module VCR
       module YAML
         extend self
         extend EncodingErrorHandling
+        extend SyntaxErrorHandling
 
         # @private
         ENCODING_ERRORS = [ArgumentError]
+
+        # @private
+        SYNTAX_ERRORS = [::Psych::SyntaxError]
 
         # The file extension to use for this serializer.
         #
@@ -42,7 +46,9 @@ module VCR
         # @return [Hash] the deserialized object
         def deserialize(string)
           handle_encoding_errors do
-            ::YAML.load(string)
+            handle_syntax_errors do
+              ::YAML.load(string)
+            end
           end
         end
       end


### PR DESCRIPTION
When deserializing a cassette and encountering a syntax error, the error message can be confusing. This is exacerbated in projects using Rails' backtrace silencer, as the error has no apparent source outside the test itself.

One common scenario resulting in syntax errors is the use of ERB in the cassette, but omitting the `:erb` option to `use_cassette`.

For example, a cassette containing may contain a JSON snippet for an API call where a field is populated using

```json
"field": <%= "some computed value".to_json %>
```

If given `erb: true`, this will work fine, but if this is forgotten, a syntax error will be encountered.

This change appends to the error's message, indicating that the error was encountered reading a VCR cassette, and suggesting the use of the `:erb` option.