### PR TITLE
YAML Serializer: use unsafe_load if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 - [breaking] Drop support for ancient typhoeus 0.4 (#905)
 - [new] Add `VCR.turned_on` similar to `VCR.turned_off` (#681)
 - [fix] cassettes will match URIs with trailing dot. eg `example.com.` (#834)
+- [fix] Use `YAML.unsafe_load` if available to load cassette data (better compatibility with Psych 4.0). (#911)
 - [patch] Improve error message for syntax error in ERB-using cassettes (#909)
 - [patch] Handle `use_cassette(..., erb: {})` (#908) 
 

--- a/lib/vcr/cassette/serializers/yaml.rb
+++ b/lib/vcr/cassette/serializers/yaml.rb
@@ -47,7 +47,11 @@ module VCR
         def deserialize(string)
           handle_encoding_errors do
             handle_syntax_errors do
-              ::YAML.load(string)
+              if ::YAML.respond_to?(:unsafe_load)
+                ::YAML.unsafe_load(string)
+              else
+                ::YAML.load(string)
+              end
             end
           end
         end


### PR DESCRIPTION
Psych 4.0 made `YAML.load` safe by default, meaning it won't deserialize arbitrary types.

This causes us problem because some of our cassette have `OpenSSL::Buffering::Buffer` instances serialized.