### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.1", "3.0", "2.7", "2.6", "2.5"]
+        ruby-version: ["3.1", "3.0", "2.7", "2.6"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## Unreleased changes
 [Full Changelog](https://github.com/vcr/vcr/compare/v6.0.0...master)
 
+- [breaking] Remove support for Ruby 2.5, require 2.6 or newer (#914)
 - [breaking] Remove support for Ruby 2.4, require Ruby 2.5 or newer (#900)
 - [breaking] JSON-serializer generates pretty-formatted output.
 - [breaking] Drop support for ancient typhoeus 0.4 (#905)

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ VCR follows the principles of [semantic versioning](https://semver.org/). The [A
 
 VCR versions 6.x are tested on the following ruby interpreters:
 
+  * MRI 3.1
   * MRI 3.0
   * MRI 2.7
   * MRI 2.6
-  * MRI 2.5
-  
-Note that as of after VCR 6.0.0, only >= 2.5 is explicitly supported. 6.0.0 supported >= 2.4.
+
+[VCR 6.0.0](https://github.com/vcr/vcr/releases/tag/v6.0.0) is the last version supporting >= 2.4. Upcoming releases will only explicitly support >= 2.6.
 
 **Development**
 

--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir[File.join("bin", "**", "*")].map! { |f| f.gsub(/bin\//, "") }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
```
Ruby 2.5
status: eol
release date: 2017-12-25
EOL date: 2021-03-31
```
