### PR TITLE
Upgrade cucumber to 7.0

### DIFF
--- a/Gemfile.cucumber
+++ b/Gemfile.cucumber
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "cucumber", "~> 3.1"
+gem "cucumber", "~> 4.0"
 gem "webrick"
 
 gemspec

--- a/features/cassettes/format.feature
+++ b/features/cassettes/format.feature
@@ -78,6 +78,7 @@ Feature: Cassette format
         make_http_request(:get, "http://localhost:#{$server.port}/bar", nil, 'Accept-Encoding' => 'identity')
       end
       """
+    And I am configuring with "<configuration>" using "<http_lib>"
     When I successfully run `ruby cassette_yaml.rb 'Hello'`
     Then the file "cassettes/example.yml" should contain YAML like:
       """

--- a/features/request_matching/headers.feature
+++ b/features/request_matching/headers.feature
@@ -3,7 +3,8 @@ Feature: Matching on Headers
   Use the `:headers` request matcher to match requests on the request headers.
 
   Scenario Outline: Replay interaction that matches the headers
-    Given a previously recorded cassette file "cassettes/example.yml" with:
+    Given I am configuring with "<configuration>" using "<http_lib>"
+    And a previously recorded cassette file "cassettes/example.yml" with:
       """
       --- 
       http_interactions: 

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -40,12 +40,12 @@ module VCRHelpers
       # Some HTTP libraries include an extra space ("OK " instead of "OK")
       i.response.status.message = i.response.status.message.strip
 
-      if @scenario_parameters.to_s =~ /excon|faraday/
+      if @http_lib_config.to_s =~ /excon|faraday/
         # Excon/Faraday do not expose the status message or http version,
         # so we have no way to record these attributes.
         i.response.status.message = nil
         i.response.http_version = nil
-      elsif @scenario_parameters.to_s.include?('webmock')
+      elsif @http_lib_config.to_s.include?('webmock')
         # WebMock does not expose the HTTP version so we have no way to record it
         i.response.http_version = nil
       end
@@ -53,7 +53,7 @@ module VCRHelpers
   end
 
   def normalize_cassette_content(content)
-    return content unless @scenario_parameters.to_s.include?('patron')
+    return content unless @http_lib_config.to_s.include?('patron')
     cassette_hash = YAML.load(content)
     cassette_hash['http_interactions'].map! do |hash|
       VCR::HTTPInteraction.from_hash(hash).tap do |i|
@@ -94,6 +94,10 @@ Given(/^that port numbers in "([^"]*)" are normalized to "([^"]*)"$/) do |file_n
     contents = contents.gsub(/:\d{2,}\//, ":#{port}/")
     File.open(file_name, 'w') { |f| f.write(contents) }
   end
+end
+
+Given(/^I am configuring with "([^"]*)" using "([^"]*)"$/) do |configuration, adapter_name|
+  @http_lib_config = [ configuration, adapter_name ]
 end
 
 When(/^I modify the file "([^"]*)" to replace "([^"]*)" with "([^"]*)"$/) do |file_name, orig_text, new_text|

--- a/features/support/http_lib_filters.rb
+++ b/features/support/http_lib_filters.rb
@@ -32,12 +32,6 @@ if defined?(UNSUPPORTED_HTTP_LIBS)
   end
 end
 
-# Set a global based on the current stubbing lib so we can put special-case
-# logic in our step definitions based on the http stubbing library.
 Before do |scenario|
-  if scenario.respond_to?(:cell_values)
-    @scenario_parameters = scenario.cell_values
-  else
-    @scenario_parameters = nil
-  end
+  @http_lib_config = nil
 end

--- a/features/test_frameworks/cucumber.feature
+++ b/features/test_frameworks/cucumber.feature
@@ -133,7 +133,7 @@ Feature: Usage with Cucumber
     And the file "features/cassettes/nested_cassette.yml" should contain "Hello nested_cassette"
     And the file "features/cassettes/allowed.yml" should contain "Hello allowed"
     And the file "features/cassettes/VCR_example/tagged_scenario.yml" should contain "Hello localhost_request_1"
-    And the file "features/cassettes/VCR_example/tagged_scenario_outline/_foo_bar_.yml" should contain "Hello localhost_request_1"
+    And the file "features/cassettes/VCR_example/tagged_scenario_outline/Example_at_line_33.yml" should contain "Hello localhost_request_1"
 
     # Run again without the server; we'll get the same responses because VCR
     # will replay the recorded responses.
@@ -149,7 +149,7 @@ Feature: Usage with Cucumber
     And the file "features/cassettes/nested_cassette.yml" should contain "Hello nested_cassette"
     And the file "features/cassettes/allowed.yml" should contain "Hello allowed"
     And the file "features/cassettes/VCR_example/tagged_scenario.yml" should contain "Hello localhost_request_1"
-    And the file "features/cassettes/VCR_example/tagged_scenario_outline/_foo_bar_.yml" should contain "Hello localhost_request_1"
+    And the file "features/cassettes/VCR_example/tagged_scenario_outline/Example_at_line_33.yml" should contain "Hello localhost_request_1"
 
   Scenario: `:allow_unused_http_interactions => false` does not raise if the scenario already failed
     Given a previously recorded cassette file "features/cassettes/cucumber_tags/example.yml" with:

--- a/features/test_frameworks/cucumber.feature
+++ b/features/test_frameworks/cucumber.feature
@@ -132,8 +132,8 @@ Feature: Usage with Cucumber
     And the file "features/cassettes/cucumber_tags/localhost_request.yml" should contain "Hello localhost_request_2"
     And the file "features/cassettes/nested_cassette.yml" should contain "Hello nested_cassette"
     And the file "features/cassettes/allowed.yml" should contain "Hello allowed"
-    And the file "features/cassettes/VCR_example/tagged_scenario.yml" should contain "Hello localhost_request_1"
-    And the file "features/cassettes/VCR_example/tagged_scenario_outline/Example_at_line_33.yml" should contain "Hello localhost_request_1"
+    And the file "features/cassettes/vcr_example/tagged_scenario.yml" should contain "Hello localhost_request_1"
+    And the file "features/cassettes/vcr_example/tagged_scenario_outline/Example_at_line_33.yml" should contain "Hello localhost_request_1"
 
     # Run again without the server; we'll get the same responses because VCR
     # will replay the recorded responses.
@@ -148,8 +148,8 @@ Feature: Usage with Cucumber
     And the file "features/cassettes/cucumber_tags/localhost_request.yml" should contain "Hello localhost_request_2"
     And the file "features/cassettes/nested_cassette.yml" should contain "Hello nested_cassette"
     And the file "features/cassettes/allowed.yml" should contain "Hello allowed"
-    And the file "features/cassettes/VCR_example/tagged_scenario.yml" should contain "Hello localhost_request_1"
-    And the file "features/cassettes/VCR_example/tagged_scenario_outline/Example_at_line_33.yml" should contain "Hello localhost_request_1"
+    And the file "features/cassettes/vcr_example/tagged_scenario.yml" should contain "Hello localhost_request_1"
+    And the file "features/cassettes/vcr_example/tagged_scenario_outline/Example_at_line_33.yml" should contain "Hello localhost_request_1"
 
   Scenario: `:allow_unused_http_interactions => false` does not raise if the scenario already failed
     Given a previously recorded cassette file "features/cassettes/cucumber_tags/example.yml" with:

--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "hashdiff", ">= 1.0.0.beta1", "< 2.0.0"
-  spec.add_development_dependency "cucumber", "~> 3.1"
+  spec.add_development_dependency "cucumber", "~> 7.0"
   spec.add_development_dependency "aruba", "~> 0.14.14"
   spec.add_development_dependency "faraday", ">= 0.11.0", "< 2.0.0"
   spec.add_development_dependency "httpclient"


### PR DESCRIPTION
Hi there, 🙌 

Built this on top of #902  (Hope you don't mind @aka47 ! I had some time to dig around 🙌 )

The main issue was related to the removal of `scenario.cell_values` on https://github.com/cucumber/cucumber-ruby/pull/1309 And the current HTTP config had to be available for the helpers in some other way.

Also, another spec had to be updated to match the new file_name for cucumber v4+ from #845 :)