### PR TITLE
Dont attempt to parse a invalid response(nil) when using `hook_into :excon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
 - [patch] Improve error message for syntax error in ERB-using cassettes (#909)
 - [patch] Handle `use_cassette(..., erb: {})` (#908) 
 - [fix] Use fiber-local for `global_hook_disabled_requests` (#907) 
+- [fix] Dont attempt to parse a nil response when hooking into `:excon` (#916)
 
 ## 6.0.0 (May 28, 2020)
 [Full Changelog](https://github.com/vcr/vcr/compare/v5.1.0...v6.0.0)

--- a/lib/vcr/middleware/excon.rb
+++ b/lib/vcr/middleware/excon.rb
@@ -74,7 +74,7 @@ module VCR
         def after_request(response)
           vcr_response = vcr_response_for(response)
 
-          if should_record?
+          if vcr_response && should_record?
             VCR.record_http_interaction(VCR::HTTPInteraction.new(vcr_request, vcr_response))
           end
 


### PR DESCRIPTION
Hi 🙌 

When using `hook_into :excon` and dealing with an internal error from Excon(i.e: OpenSSL::SSL::SSLError) `VCR::Middleware::Excon::Response#error_call` was breaking because it was trying to parse/record a nil response. The error happened [here on Logger#response_summary](https://github.com/vcr/vcr/blob/master/lib/vcr/util/logger.rb#L23), because `response` is nil. 

I think that the correct behavior would be to let Excon throw its own error up the stack as there's nothing recorded yet [here](https://github.com/excon/excon/blob/dc10c8b4a1f7ef3a166352c911c40a3f1027056a/lib/excon/connection.rb#L106-L110) and there's no need for VCR to attempt to read an empty response for this scenario. Please, correct me if I'm wrong.

When using `hook_into :webmock`  the error is thrown and no cassette is recorded. Same things happens here now.

Fixes #651 