### PR TITLE
Handle the potential renaming of `ASCII-8BIT`

### DIFF
--- a/Upgrade.md
+++ b/Upgrade.md
@@ -275,7 +275,7 @@ be configured globally with a block, or set on individual cassettes:
 ``` ruby
 VCR.configure do |c|
   c.preserve_exact_body_bytes do |http_message|
-    http_message.body.encoding.name == 'ASCII-8BIT' ||
+    http_message.body.encoding == Encoding::BINARY ||
     !http_message.body.valid_encoding?
   end
 end

--- a/features/configuration/preserve_exact_body_bytes.feature
+++ b/features/configuration/preserve_exact_body_bytes.feature
@@ -34,7 +34,7 @@ Feature: Preserve Exact Body Bytes
         c.cassette_library_dir = 'cassettes'
         c.hook_into :webmock
         c.preserve_exact_body_bytes do |http_message|
-          http_message.body.encoding.name == 'ASCII-8BIT' ||
+          http_message.body.encoding == Encoding::BINARY ||
           !http_message.body.valid_encoding?
         end
       end

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -460,7 +460,7 @@ module VCR
     # @example
     #   VCR.configure do |c|
     #     c.preserve_exact_body_bytes do |http_message|
-    #       http_message.body.encoding.name == 'ASCII-8BIT' ||
+    #       http_message.body.encoding == Encoding::BINARY ||
     #       !http_message.body.valid_encoding?
     #     end
     #   end

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -31,13 +31,16 @@ module VCR
             string.force_encoding(encoding)
           end
 
-          def try_encode_string(string, encoding)
-            return string if encoding.nil? || string.encoding.name == encoding
+          def try_encode_string(string, encoding_name)
+            return string if encoding_name.nil?
+
+            encoding = Encoding.find(encoding_name)
+            return string if string.encoding == encoding
 
             # ASCII-8BIT just means binary, so encoding to it is nonsensical
             # and yet "\u00f6".encode("ASCII-8BIT") raises an error.
             # Instead, we'll force encode it (essentially just tagging it as binary)
-            return string.force_encoding(encoding) if encoding == "ASCII-8BIT"
+            return string.force_encoding(encoding) if encoding == Encoding::BINARY
 
             string.encode(encoding)
           rescue EncodingError => e

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -187,7 +187,7 @@ module VCR
 
           i = HTTPInteraction.from_hash(hash)
           expect(i.request.body).to eq('foo')
-          expect(i.request.body.encoding.name).to eq("ASCII-8BIT")
+          expect(i.request.body.encoding).to eq(Encoding::BINARY)
         end
 
         it 'tries to encode strings to the original encoding' do
@@ -221,7 +221,7 @@ module VCR
           i = HTTPInteraction.from_hash(hash)
           expect(i.request.body).to eq(string)
           expect(i.request.body.bytes.to_a).to eq(string.bytes.to_a)
-          expect(i.request.body.encoding.name).to eq("ASCII-8BIT")
+          expect(i.request.body.encoding).to eq(Encoding::BINARY)
         end
 
         context 'when the string cannot be encoded as the original encoding' do
@@ -318,7 +318,7 @@ module VCR
 
       it "sets the string's original encoding", :if => ''.respond_to?(:encoding) do
         interaction.request.body.force_encoding('ISO-8859-10')
-        interaction.response.body.force_encoding('ASCII-8BIT')
+        interaction.response.body.force_encoding(Encoding::BINARY)
 
         expect(hash['request']['body']['encoding']).to eq('ISO-8859-10')
         expect(hash['response']['body']['encoding']).to eq('ASCII-8BIT')


### PR DESCRIPTION
This is a bit of a weird one. I proposed that `ASCII-8BIT` be renamed to `BINARY` https://bugs.ruby-lang.org/issues/18576

And this code came up as a potentially broken by this change. It's still possible that the name change may happen, that's why I'm submitting this PR.