### PR TITLE
Lock faraday to version 1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       ALL_WARNINGS: "/tmp/all-warnings"
 
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ["3.1", "3.0", "2.7", "2.6", "2.5"]
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "faraday", ">= 0.9.2"
+gem "faraday", ">= 0.9.2", "< 2"
 
 gemspec
 

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe VCR do
 
     it 'forwards the given options to `Cassette#eject`' do
       cassette = insert_cassette
-      expect(cassette).to receive(:eject).with(:some => :options)
+      expect(cassette).to receive(:eject).with({ :some => :options })
       VCR.eject_cassette(:some => :options)
     end
 
@@ -341,7 +341,7 @@ RSpec.describe VCR do
     end
 
     it 'passes options through to .turn_off!' do
-      expect(VCR).to receive(:turn_off!).with(:ignore_cassettes => true)
+      expect(VCR).to receive(:turn_off!).with({ :ignore_cassettes => true })
       VCR.turned_off(:ignore_cassettes => true) { }
     end
   end
@@ -363,7 +363,7 @@ RSpec.describe VCR do
     end
 
     it 'passes options through to .turn_off!' do
-      expect(VCR).to receive(:turn_off!).with(:ignore_cassettes => true)
+      expect(VCR).to receive(:turn_off!).with({ :ignore_cassettes => true })
       VCR.turned_on(:ignore_cassettes => true) { }
     end
   end


### PR DESCRIPTION
CI is fully broken because of faraday 2 right now:

```
An error occurred while loading ./spec/acceptance/concurrency_spec.rb.
Failure/Error: require 'typhoeus/adapters/faraday'

NameError:
  method `call' not defined in Faraday::Adapter::Typhoeus

        remove_method :call              if method_defined? :call
        ^^^^^^^^^^^^^
# ./vendor/bundle/ruby/3.1.0/gems/typhoeus-1.1.2/lib/typhoeus/adapters/faraday.rb:28:in `remove_method'
# ./vendor/bundle/ruby/3.1.0/gems/typhoeus-1.1.2/lib/typhoeus/adapters/faraday.rb:28:in `<class:Typhoeus>'
```

Seem like Typhoeus doesn't support faraday 2 yet: https://github.com/typhoeus/typhoeus/issues/686