### PR TITLE
Remove MIT license tag #806 #810

### DIFF
--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.}
   spec.description   = spec.summary
   spec.homepage      = "https://relishapp.com/vcr/vcr/docs"
-  spec.licenses       = ["Hippocratic-2.1", "MIT"]
+  spec.license       = "Hippocratic-2.1"
 
   spec.files         = Dir[File.join("lib", "**", "*")]
   spec.executables   = Dir[File.join("bin", "**", "*")].map! { |f| f.gsub(/bin\//, "") }


### PR DESCRIPTION
The license(s) tag in the `.gemspec` file is used for the license(s) that apply to the package as a whole not for licenses that only apply to some portion of it.

https://guides.rubygems.org/specification-reference/#licenses=