### PR TITLE
Remove unnecessary information from test runner output

### DIFF
--- a/spec/lib/vcr/library_hooks/faraday_spec.rb
+++ b/spec/lib/vcr/library_hooks/faraday_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe "Faraday hook" do
       VCR.use_cassette('no_body') do
         conn = Faraday.new(:url => "http://localhost:#{VCR::SinatraApp.port}") do |builder|
           builder.request  :url_encoded
-          builder.response :logger
           builder.adapter  :net_http
         end
         conn.get("localhost_test") do |request|


### PR DESCRIPTION
Expected 'bundle exec rspec' to only show progress and test suite
relevant information.

Actual output contains request and response details alongside the test
progress output:
```
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 53488
....I, [2022-04-17T18:59:48.433699 #51793]  INFO -- request: GET http://localhost:53392/localhost_test
I, [2022-04-17T18:59:48.433787 #51793]  INFO -- request: User-Agent: "Faraday v1.10.0"
I, [2022-04-17T18:59:48.448329 #51793]  INFO -- response: Status 200
I, [2022-04-17T18:59:48.448476 #51793]  INFO -- response: content-type: "text/html;charset=utf-8"
content-length: "18"
server: "WEBrick/1.7.0 (Ruby/3.1.2/2022-04-12)"
date: "Sun, 17 Apr 2022 17:59:48 GMT"
connection: "Keep-Alive"
I, [2022-04-17T18:59:48.451178 #51793]  INFO -- request: GET http://localhost:53392/localhost_test
I, [2022-04-17T18:59:48.451242 #51793]  INFO -- request: User-Agent: "Faraday v1.10.0"
I, [2022-04-17T18:59:48.454387 #51793]  INFO -- response: Status 200
I, [2022-04-17T18:59:48.454450 #51793]  INFO -- response: content-type: "text/html;charset=utf-8"
content-length: "18"
server: "WEBrick/1.7.0 (Ruby/3.1.2/2022-04-12)"
date: "Sun, 17 Apr 2022 17:59:48 GMT"
connection: "Keep-Alive"
.

Finished in 0.04076 seconds (files took 1.09 seconds to load)
5 examples, 0 failures
```