### PR TITLE
CI: apt update before apt install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install OS dependencies
-      run: sudo apt-get install --assume-yes libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --assume-yes libcurl4-openssl-dev
 
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Fixes build failures foundin #935. 

This PR fixes those unrelated failures.

<details>

```
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  libcurl4-doc libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev
The following NEW packages will be installed:
  libcurl4-openssl-dev
0 upgraded, 1 newly installed, 0 to remove and 15 not upgraded.
Need to get 321 kB of archives.
After this operation, 1541 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.7
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.7
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.68.0-1ubuntu2.7_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

</details>