### PR TITLE
Fix recompressing response to happen after replacing sensitive data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- [fix] Fix recompressing response to happen after replacing sensitive data (#951) by @cgunther
+
 ## 6.4.0 (Dec 11, 2025)
 [Full Changelog](https://github.com/vcr/vcr/compare/v6.3.1...v6.4.0)
 
@@ -50,12 +52,12 @@ Changelog
 - [fix] Use `YAML.unsafe_load` if available to load cassette data (better compatibility with Psych 4.0). (#911) by @casperisfine
 - [patch] Improve error message for syntax error in ERB-using cassettes (#909) by @sambostock
 - [patch] Handle `use_cassette(..., erb: {})` (#908) by @sambostock
-- [fix] Use fiber-local for `global_hook_disabled_requests` (#907) by @jhawthorn 
+- [fix] Use fiber-local for `global_hook_disabled_requests` (#907) by @jhawthorn
 - [docs] Document the RSpec cassette name shorthand (#821) by @nicolasiensen
 - [fix] Fix the behavior of the option re_record_interval "none" (#824) by @nicolasiensen
 - [fix] Fix compatibility with frozen string literals (#832) by @casperisfine
 - [fix] [Transforms ERB hash keys to symbol, in case string (#833) by @z1lk
-- [fix] Support Cucumber-Ruby v4 and later (#845) by @brasmusson 
+- [fix] Support Cucumber-Ruby v4 and later (#845) by @brasmusson
 - [patch] Extract `#vcr_cassette_name_for` (#882) by @dabroz
 - [fix] Fix CI to use GitHub Actions (#883) by @bradshjg
 - [new] Add `#localhost_ignored?` to request_ignorer (#895) by @ThHareau

--- a/features/cassettes/recompress.feature
+++ b/features/cassettes/recompress.feature
@@ -1,0 +1,75 @@
+Feature: Recompress response
+
+  When the `:recompress_response` option is set to a truthy value, VCR will
+  recompress "gzip" and "deflate" response bodies that were previously
+  decompressed via `:decode_compressed_response` before playback.
+
+  Background:
+    Given a file named "recompress.rb" with:
+        """ruby
+        require 'zlib'
+        require 'stringio'
+
+        $server = start_sinatra_app do
+          get('/') {
+            content = "The quick brown fox jumps over the lazy dog"
+            io = StringIO.new
+
+            writer = Zlib::GzipWriter.new(io)
+            writer << content
+            writer.close
+
+            headers['Content-Encoding'] = 'gzip'
+            io.string
+          }
+        end
+
+        require 'vcr'
+
+        VCR.configure do |c|
+          c.cassette_library_dir = 'cassettes'
+          c.hook_into :webmock
+          c.default_cassette_options = { :serialize_with => :syck }
+          c.filter_sensitive_data('<COLOR>') { 'brown' }
+        end
+
+        VCR.use_cassette(:recompress, :decode_compressed_response => true) do
+          Net::HTTP.start('localhost', $server.port) do |http|
+            http.get('/', 'accept-encoding' => 'identity')
+          end
+        end
+        """
+
+  Scenario: The option is not set by default
+    When I append to file "recompress.rb":
+      """ruby
+      VCR.use_cassette(:recompress) do
+        response = Net::HTTP.get_response('localhost', '/', $server.port)
+        puts "Content-Encoding: #{response['Content-Encoding'] || 'none'}"
+      end
+      """
+    And I run `ruby recompress.rb`
+    Then it should pass with "Content-Encoding: none"
+
+  Scenario: The option is enabled
+    When I append to file "recompress.rb":
+      """ruby
+      VCR.use_cassette(:recompress, :recompress_response => true) do
+        response = Net::HTTP.get_response('localhost', '/', $server.port)
+        puts "Content-Encoding: #{response['Content-Encoding'] || 'none'}"
+      end
+      """
+    And I run `ruby recompress.rb`
+    Then it should pass with "Content-Encoding: gzip"
+
+  Scenario: The recompressing happens after replacing filtered sensitive data
+    When I append to file "recompress.rb":
+      """ruby
+      VCR.use_cassette(:recompress, :recompress_response => true) do
+        VCR::Response.decompress(Net::HTTP.get_response('localhost', '/', $server.port).body, 'gzip') do |body|
+          puts body
+        end
+      end
+      """
+      And I run `ruby recompress.rb`
+      Then it should pass with "The quick brown fox jumps over the lazy dog"

--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -214,6 +214,7 @@ module VCR
       @previously_recorded_interactions ||= if !raw_cassette_bytes.to_s.empty?
         deserialized_hash['http_interactions'].map { |h| HTTPInteraction.from_hash(h) }.tap do |interactions|
           invoke_hook(:before_playback, interactions)
+          invoke_hook(:recompress_response, interactions)
 
           interactions.reject! do |i|
             i.request.uri.is_a?(String) && VCR.request_ignorer.ignore?(i.request)

--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -566,8 +566,10 @@ module VCR
       lambda { |arg| arg.send(object) }
     end
 
+    define_hook :recompress_response
+
     def register_built_in_hooks
-      before_playback(:recompress_response) do |interaction|
+      recompress_response(tag_filter_from(:recompress_response)) do |interaction|
         interaction.response.recompress if interaction.response.vcr_decompressed?
       end
 

--- a/spec/lib/vcr/cassette_spec.rb
+++ b/spec/lib/vcr/cassette_spec.rb
@@ -398,6 +398,8 @@ RSpec.describe VCR::Cassette do
           it 'invokes the before_playback hooks' do
             VCR.configuration.cassette_library_dir = "#{VCR::SPEC_ROOT}/fixtures/cassette_spec"
 
+            allow(VCR.configuration).to receive(:invoke_hook).and_return([false])
+
             expect(VCR.configuration).to receive(:invoke_hook).with(
               :before_playback,
               an_instance_of(VCR::HTTPInteraction::HookAware),


### PR DESCRIPTION
Using a combination of `recompress_response` and `filter_sensitive_data`, previously VCR would recompress the response first, then try to replace the sensitive data placeholders with the actual value, however once it's recompressed, the placeholders can't be found anymore to replace. Therefore, once your app/library decoded the recompressed response itself, the placeholders were still there, instead of the expected values.

This happened because both actions were handled by `before_playback` hooks. The recompress hook was registered first upon initialization of the config instance, then the sensitive data hook was registered upon calling `filter_sensitive_data` (always after initiating the config instance), leading VCR to run them in order, recompressing then replacing.

To ensure recompressing always happens last, after all `before_playback` hooks run, I added a new specific hook, `recompress_response`, that gets invoked right after invoking the `before_playback` hook. This assumes you'd never want to run a `before_playback` hook after recompressing.

My usecase is that I'm using the braintree gem, which [requires gzipped responses][1], however the response has "sensitive" data that I want to commit with a placeholder since the value might vary across developer machines, so I use `decode_compressed_response` and `filter_sensitive_data` so that my committed cassettes use a placeholder, then combine it with `recompress_response` so the braintree gem can see the responses as gzipped upon playback, with the placeholders replaced.

[1]: https://github.com/braintree/braintree_ruby/blob/7d4182b7407bd66061faacadec54960e6c876f72/lib/braintree/http.rb#L174-L180