### PR TITLE
Do not mask error when ignore_cassettes is true

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -193,7 +193,7 @@ module VCR
     begin
       call_block(block, cassette)
     rescue StandardError
-      cassette.run_failed!
+      cassette&.run_failed!
       raise
     ensure
       eject_cassette

--- a/spec/lib/vcr_spec.rb
+++ b/spec/lib/vcr_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe VCR do
         insert_cassette(:foo)
       }.to raise_error(/There is already a cassette with the same name/)
     end
+
+    it 'does not mask the error if ignore_cassettes is true' do
+      expect {
+        VCR.turn_off!(ignore_cassettes: true)
+
+        VCR.use_cassette(:foo) do
+          raise StandardError, 'Original Error'
+        end
+
+        VCR.turn_on!
+     }.to raise_error(/Original Error/)
+    end
   end
 
   describe '.eject_cassette' do


### PR DESCRIPTION
When turning VCR cassettes off and using `ignore_cassettes: true` any `use_cassette` blocks will be executed as normal.  But if an error is raised within the test - that error will be caught in the `use_cassette` method.  The cassette in this method will not exist, because the `ignore_cassettes` flag causes it to not be inserted.  A `NoMethodError` will be raised when VCR attempts to call `run_failed!` on the non-existent cassette.

Let's use the safe navigation operator to conditionally not mark a cassette as failed if it doesn't exist!