### PR TITLE
Add Ruby 3.2 to build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.1", "3.0", "2.7", "2.6"]
+        ruby-version: ["3.2", "3.1", "3.0", "2.7", "2.6"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I ran into an issue with cassette serialization on a project that recently migrated to 3.2 (Psych throws a `RuntimeError` when VCR dumps the cassette to YAML, still looking into that separately) and noticed that 3.2 wasn't a part of the current CI - thought it'd be helpful to add.

Need to validate this change in CI before making any adjustments (tests pass locally, bundle platform `arm64-darwin-22`, but additional libraries may be needed for CI builds using Ubuntu)

Released a month ago, notes: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/