### PR TITLE
Fix CI builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ platform :mri do
   gem 'webrick'
   gem "typhoeus", "~> 1.1.0"
   gem "patron", "0.6.3"
+  # TODO: Remove the pinned version of `ethon` once header issue affecting Typhoeus is resolved
+  # https://github.com/typhoeus/typhoeus/issues/705
+  gem "ethon", "0.15.0"
   gem "em-http-request"
   gem "curb", "~> 1.0.1"
 end


### PR DESCRIPTION
There has been a Typhoeus spec that has been failing in this project for a few months (most recently in https://github.com/vcr/vcr/pull/962), it seems to be tied to the 0.16.0 release of the `ethon` gem (https://github.com/typhoeus/ethon/compare/v0.15.0...v0.16.0)

Failure

```ruby
  1) Typhoeus hook when using on_headers callback is expected to yield with args(have attributes {:headers => (include {"Content-Length" => "18"})})
     Failure/Error: it { expect { |b| on_headers(&b) }.to yield_with_args(have_attributes(headers: include('Content-Length' => '18'))) }

       expected given block to yield with arguments, but yielded with unexpected arguments
       expected: [(have attributes {:headers => (include {"Content-Length" => "18"})})]
            got: [#<Typhoeus::Response:0x00007f66226d9ae0 @options={:httpauth_avail=>0, :total_time=>8.2e-05, :starttr...s=>"", :response_body=>"", :debug_info=>#<Ethon::Easy::DebugInfo:0x00007f66226e4a58 @messages=[]>}>]
     # ./spec/lib/vcr/library_hooks/typhoeus_spec.rb:124:in `block (3 levels) in <top (required)>'
```