### PR TITLE
Drop ruby 26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.1", "3.0", "2.7", "2.6"]
+        ruby-version: ["3.2", "3.1", "3.0", "2.7"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Changelog
 
 [Full Changelog](https://github.com/vcr/vcr/compare/v6.1.0...master)
 
+- Drop support for Ruby 2.6.
 - [new] Add `drop_unused_requests` option to exclude unused interactions (#946) by @ryanseys and @mhuntglickman
-- [fix] Add support for on_data with Faraday (#823) by @zeisler
+- [fix] Add support for `on_data` with Faraday (#823) by @zeisler
 
 ## 6.1.0 (March 13, 2022)
 

--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir[File.join("bin", "**", "*")].map! { |f| f.gsub(/bin\//, "") }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
As a maintenance step, this PR removes support for Ruby 2.6 from the CI matrix and the gemspec.