### PR TITLE
Use proc, not lambda for Ruby 3.3 compat in structs.rb

### DIFF
--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -304,7 +304,7 @@ module VCR
       #
       # @return [Proc] the proc
       def to_proc
-        lambda { proceed }
+        proc { proceed }
       end
 
       undef method


### PR DESCRIPTION
Fixes #992 - see there for a careful explanation.

@mattbrictson said it:

In Ruby 3.3, this deprecation warning will be replaced by an actual ArgumentError. So vcr will break on Ruby 3.3. I confirmed this by running vcr's own specs on the ruby:3.3-rc docker image.

    # ruby -v
    ruby 3.3.0preview2 (2023-09-14 master e50fcca9a7) [x86_64-linux] # bundle exec rspec spec/lib/vcr/structs_spec.rb
    
    Failures:
    
      1) VCR::Request VCR::Request::FiberAware can be cast to a proc
         Failure/Error: lambda { proceed }
         
         ArgumentError:
           the lambda method requires a literal block
         # ./lib/vcr/structs.rb:307:in `to_proc'
         # ./spec/lib/vcr/structs_spec.rb:584:in `block (3 levels) in <module:VCR>'