### PR TITLE
Remove duplicate cucumber CI step and publish warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,10 @@ jobs:
       run: |
         bundle install
         bundle exec yard stats --list-undoc | tee /dev/stdout | grep -q '100.00% documented'
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ALL_WARNINGS
+        path: /tmp/all-warnings
+        retention-days: 7
+        if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,6 @@ jobs:
       env:
         BUNDLE_GEMFILE: Gemfile.faraday-1.0.0
 
-    - name: cucumber
-      run: |
-        bundle install
-        bundle exec cucumber features/test_frameworks/cucumber.feature 2>> "${ALL_WARNINGS}"
-      env:
-        BUNDLE_GEMFILE: Gemfile.cucumber
-
     - name: rspec
       run: |
         bundle install
@@ -57,6 +50,8 @@ jobs:
       run: |
         bundle install
         bundle exec cucumber features/ 2>> "${ALL_WARNINGS}"
+      env:
+        BUNDLE_GEMFILE: Gemfile.cucumber
 
     - name: check warnings
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      BUNDLE_GEMFILE: Gemfile.cucumber
       RUBYOPT: "-w"
       ALL_WARNINGS: "/tmp/all-warnings"
 
@@ -91,10 +92,7 @@ jobs:
 
     - name: cucumber
       run: |
-        bundle install
         bundle exec cucumber features/ 2>> "${ALL_WARNINGS}"
-      env:
-        BUNDLE_GEMFILE: Gemfile.cucumber
 
     - name: check warnings
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: cucumber
       run: |
-        bundle exec cucumber features/ 2>> "${ALL_WARNINGS}"
+        bundle exec cucumber features/
 
     - name: check warnings
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,13 +46,6 @@ jobs:
         bundle install
         bundle exec rspec spec/ 2>> "${ALL_WARNINGS}"
 
-    - name: cucumber
-      run: |
-        bundle install
-        bundle exec cucumber features/ 2>> "${ALL_WARNINGS}"
-      env:
-        BUNDLE_GEMFILE: Gemfile.cucumber
-
     - name: check warnings
       run: |
         vcr_warnings="$(grep -F "$PWD" "${ALL_WARNINGS}" | grep "warning: " | grep -v "${PWD}/vendor/bundle" | sort | uniq -c | tee /dev/stderr | wc -l)"
@@ -65,7 +58,52 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       with:
-        name: ALL_WARNINGS
+        name: ALL_WARNINGS-test
+        path: /tmp/all-warnings
+        retention-days: 7
+        if-no-files-found: ignore
+
+  cucumber:
+    runs-on: ubuntu-latest
+
+    env:
+      RUBYOPT: "-w"
+      ALL_WARNINGS: "/tmp/all-warnings"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ["3.2", "3.1", "3.0", "2.7"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install OS dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install --assume-yes libcurl4-openssl-dev
+
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+
+    - name: cucumber
+      run: |
+        bundle install
+        bundle exec cucumber features/ 2>> "${ALL_WARNINGS}"
+      env:
+        BUNDLE_GEMFILE: Gemfile.cucumber
+
+    - name: check warnings
+      run: |
+        vcr_warnings="$(grep -F "$PWD" "${ALL_WARNINGS}" | grep "warning: " | grep -v "${PWD}/vendor/bundle" | sort | uniq -c | tee /dev/stderr | wc -l)"
+        if [ "$vcr_warnings" -gt 0 ]; then echo "FAILED: test suite doesn't tolerate warnings"; exit 1; fi
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ALL_WARNINGS-cucumber
         path: /tmp/all-warnings
         retention-days: 7
         if-no-files-found: ignore


### PR DESCRIPTION
This PR makes two changes to troubleshoot/fix #995 (CI failures).

1. Remove duplicate `cucumber` step that seemed redundant.
2. Uses `actions/upload-artifact` to upload the warnings that are captured from stderr so they can be inspected after the fact.