### PR TITLE
Pin activesupport < 7.1 to work around cucumber failure

### DIFF
--- a/Gemfile.cucumber
+++ b/Gemfile.cucumber
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "activesupport", "< 7.1" # work around cucumber breaking with 7.1
 gem "cucumber", "~> 4.0"
 gem "webrick"
 


### PR DESCRIPTION
This is a workaround for the issue described in detail here: https://github.com/vcr/vcr/issues/995#issuecomment-1769078881

Fixes #995 