### PR TITLE
Upgrade cucumber to fix CI failures

### DIFF
--- a/Gemfile.cucumber
+++ b/Gemfile.cucumber
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "cucumber", "~> 4.0"
+gem "cucumber", "~> 9.0"
 gem "webrick"
 
 gemspec


### PR DESCRIPTION
Previously, CI was using cucumber 4.x, which is not compatible with the recently-released Active Support 7.1 (see #995 discussion).

This commit upgrades cucumber to the latest major version (9.x), which fixes the CI failures.

Fixes #995