### PR TITLE
Drop runtime dependency on base64

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 gem "ethon", "0.15.0"
 
 gem "aruba", "~> 0.14.14"
+gem "base64"
 gem "bigdecimal"
 gem "codeclimate-test-reporter", "~> 0.4"
 gem "cucumber", "~> 9.0"

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -1,4 +1,3 @@
-require 'base64'
 require 'delegate'
 require 'time'
 
@@ -18,8 +17,8 @@ module VCR
           hash = hash_or_string
 
           if hash.has_key?('base64_string')
-            string = Base64.decode64(hash['base64_string'])
-            force_encode_string(string, hash['encoding'])
+            base64_decoded = hash['base64_string'].unpack1('m')
+            force_encode_string(base64_decoded, hash['encoding'])
           else
             try_encode_string(hash['string'], hash['encoding'])
           end
@@ -85,7 +84,8 @@ module VCR
         body = String.new(self.body.to_s)
 
         if VCR.configuration.preserve_exact_body_bytes_for?(self)
-          base_body_hash(body).merge('base64_string' => Base64.encode64(body))
+          base64_encoded = [body].pack('m')
+          base_body_hash(body).merge('base64_string' => base64_encoded)
         else
           base_body_hash(body).merge('string' => body)
         end

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -2,6 +2,7 @@
 
 require 'support/ruby_interpreter'
 
+require 'base64'
 require 'yaml'
 require 'vcr/structs'
 require 'vcr/errors'
@@ -744,4 +745,3 @@ module VCR
     end
   end
 end
-

--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7"
-
-  spec.add_dependency "base64"
 end


### PR DESCRIPTION
#1003 added `base64` as a runtime dependency. It's easy enough to replace, the `base64` is for the most part a wrapper around the `pack`/`unpack` methods.

Also see:
* https://github.com/lostisland/faraday/pull/1541
* https://github.com/bblimke/webmock/pull/1046
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/rack/rack/pull/2110
* etc.

I have made it a dev dependency since once test file uses it in a bunch of places and replacing all that doesn't make the code much better.