### PR TITLE
Replace HeaderDowncaser with Hash#transform_keys

### DIFF
--- a/spec/support/http_library_adapters.rb
+++ b/spec/support/http_library_adapters.rb
@@ -1,18 +1,6 @@
-module HeaderDowncaser
-  def downcase_headers(headers)
-    {}.tap do |downcased|
-      headers.each do |k, v|
-        downcased[k.downcase] = v
-      end
-    end
-  end
-end
-
 HTTP_LIBRARY_ADAPTERS = {}
 
 HTTP_LIBRARY_ADAPTERS['net/http'] = Module.new do
-  include HeaderDowncaser
-
   def self.http_library_name; 'Net::HTTP'; end
 
   def get_body_string(response); response.body; end
@@ -40,7 +28,7 @@ HTTP_LIBRARY_ADAPTERS['net/http'] = Module.new do
 
   def normalize_request_headers(headers)
     defined?(super) ? super :
-    downcase_headers(headers.merge(DEFAULT_REQUEST_HEADERS))
+    headers.merge(DEFAULT_REQUEST_HEADERS).transform_keys(&:downcase)
   end
 end
 

--- a/spec/support/shared_example_groups/hook_into_http_library.rb
+++ b/spec/support/shared_example_groups/hook_into_http_library.rb
@@ -3,7 +3,6 @@ require 'cgi'
 NET_CONNECT_NOT_ALLOWED_ERROR = /An HTTP request has been made that VCR does not know how to handle/
 
 shared_examples_for "a hook into an HTTP library" do |library_hook_name, library, *other|
-  include HeaderDowncaser
   include VCRStubHelpers
 
   unless adapter_module = HTTP_LIBRARY_ADAPTERS[library]
@@ -510,7 +509,7 @@ shared_examples_for "a hook into an HTTP library" do |library_hook_name, library
           end
 
           it 'records the request headers' do
-            headers = downcase_headers(recorded_interaction.request.headers)
+            headers = recorded_interaction.request.headers.transform_keys(&:downcase)
             expect(headers).to include('x-http-foo' => ['bar'])
           end
 
@@ -527,7 +526,7 @@ shared_examples_for "a hook into an HTTP library" do |library_hook_name, library
           end
 
           it 'records the response headers' do
-            headers = downcase_headers(recorded_interaction.response.headers)
+            headers = recorded_interaction.response.headers.transform_keys(&:downcase)
             expect(headers).to include('content-type' => ["text/html;charset=utf-8"])
           end
         end


### PR DESCRIPTION
VCR dropping support for Ruby 2.4 allows a VCR specific module, HeaderDowncaser, to be replaced by a Ruby standard library call Hash#transform_keys.

I didn't find any unit tests specific to the module but the support module was used throughout the RSpec test suite.

Reference

Ruby 2.5 introduced Hash#transform_keys
https://docs.ruby-lang.org/en/3.2/NEWS/NEWS-2_5_0.html

Close: #1012