### PR TITLE
Update request_ignorer.rb to add host.docker.internal as a LOCALHOST_ALIAS

### DIFF
--- a/lib/vcr/request_ignorer.rb
+++ b/lib/vcr/request_ignorer.rb
@@ -8,7 +8,7 @@ module VCR
 
     define_hook :ignore_request
 
-    LOCALHOST_ALIASES = %w( localhost 127.0.0.1 0.0.0.0 )
+    LOCALHOST_ALIASES = %w( localhost 127.0.0.1 0.0.0.0 host.docker.internal )
 
     def initialize
       ignore_request do |request|


### PR DESCRIPTION
# What's changing?
* Adds `host.docker.internal` ([a commonly used DNS alias for `localhost` used by Docker](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host)) to the list of `LOCALHOST_ALIASES`

# Testing notes
* [x] Confirmed unit test coverage [here](https://github.com/jamesmcguirepro/vcr/blob/master/spec/lib/vcr/request_ignorer_spec.rb#L55) 
* [x] Ran tests locally:
```
jamesmcguire@MAC-2FHKQ7X vcr % be rake
/Users/jamesmcguire/.asdf/installs/ruby/3.0.6/bin/ruby -I/Users/jamesmcguire/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.0/lib:/Users/jamesmcguire/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/rspec-support-3.13.1/lib /Users/jamesmcguire/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 63491
......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) VCR when used in a multithreaded environment with an around_http_request can use a cassette in an #around_http_request hook
     # This is currently very flaky...but definitely worth investigating at some point
     # ./spec/acceptance/concurrency_spec.rb:15


Finished in 16.2 seconds (files took 2.62 seconds to load)
1991 examples, 0 failures, 1 pending

Randomized with seed 63491

Coverage report generated for RSpec to /Users/jamesmcguire/repos/vcr/coverage. 5277 / 5396 LOC (97.79%) covered.
/Users/jamesmcguire/.asdf/installs/ruby/3.0.6/bin/ruby -S bundle exec cucumber
Using the default profile...
............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

253 scenarios (253 passed)
1228 steps (1228 passed)
4m23.885s
┌──────────────────────────────────────────────────────────────────────────────┐
│ Share your Cucumber Report with your team at https://reports.cucumber.io     │
│                                                                              │
│ Command line option:    --publish                                            │
│ Environment variable:   CUCUMBER_PUBLISH_ENABLED=true                        │
│ cucumber.yml:           default: --publish                                   │
│                                                                              │
│ More information at https://cucumber.io/docs/cucumber/environment-variables/ │
│                                                                              │
│ To disable this message, specify CUCUMBER_PUBLISH_QUIET=true or use the      │
│ --publish-quiet option. You can also add this to your cucumber.yml:          │
│ default: --publish-quiet                                                     │
└──────────────────────────────────────────────────────────────────────────────┘
jamesmcguire@MAC-2FHKQ7X vcr %
```