### PR TITLE
Make it possible to turn VCR on and off in a new thread

### DIFF
--- a/lib/vcr.rb
+++ b/lib/vcr.rb
@@ -335,10 +335,11 @@ module VCR
   # @see #turn_off!
   # @see #turned_off
   def turned_on?
-    linked_context = current_context[:linked_context]
-    return !linked_context[:turned_off] if linked_context
-
-    !context_value(:turned_off)
+    if !context_value(:turned_off).nil?
+      !context_value(:turned_off)
+    else
+      !current_context.dig(:linked_context, :turned_off)
+    end
   end
 
   # @private
@@ -434,15 +435,19 @@ private
 
   def dup_context(context)
     {
-      :turned_off => context[:turned_off],
-      :ignore_cassettes => context[:ignore_cassettes],
+      :turned_off => nil,
+      :ignore_cassettes => nil,
       :cassettes => [],
       :linked_context => context
     }
   end
 
   def ignore_cassettes?
-    context_value(:ignore_cassettes)
+    if !context_value(:ignore_cassettes).nil?
+      context_value(:ignore_cassettes)
+    else
+      current_context.dig(:linked_context, :ignore_cassettes)
+    end
   end
 
   def context_cassettes

--- a/spec/acceptance/threading_spec.rb
+++ b/spec/acceptance/threading_spec.rb
@@ -58,5 +58,25 @@ RSpec.describe VCR do
 
       thread.join
     end
+
+    it 'can turn on VCR in a new thread' do
+      VCR.turn_off!
+
+      Thread.new do
+        expect { VCR.turn_on! }.to change { VCR.turned_on? }.from(false).to(true)
+      end.join
+
+      expect(VCR.turned_on?).to eq(false)
+    end
+
+    it 'can turn off VCR in a new thread' do
+      expect(VCR.turned_on?).to eq(true)
+
+      Thread.new do
+        expect { VCR.turn_off! }.to change { VCR.turned_on? }.from(true).to(false)
+      end.join
+
+      expect(VCR.turned_on?).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
#764 fixed so that VCR's `:turned_off` status for the main thread can be read in a new thread, even if the status changes after the new thread was created.

However, the solution also introduced the problem that the `:turned_off` status isn't used for other threads than the main thread. This effectively makes it impossible to turn VCR on and off in a new thread.

This change, instead, creates new contexts with `:turned_off` and `:ignore_cassettes` set to `nil` by default. When the values are read, they are only used if they explicitly have been set on the thread's context. Otherwise the main thread's context is used.