### PR TITLE
Make VCR CI compatible with Faraday 1 and 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,14 @@ on:
 
 jobs:
   cucumber:
-    name: "Cucumber / ${{ matrix.ruby-version }}"
+    name: "Cucumber / Ruby ${{ matrix.ruby-version }} / Faraday ${{ matrix.faraday }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby-version: ["3.2", "3.1", "3.0", "2.7"]
+        faraday: ["1.0", "2.0"]
+    env:
+      FARADAY_VERSION: ${{ matrix.faraday }}
     steps:
       - uses: actions/checkout@v4
       - run: ./script/install-apt-deps.sh
@@ -23,11 +26,14 @@ jobs:
       - name: cucumber
         run: ./script/fail_if_warnings cucumber features/
   rspec:
-    name: "RSpec / ${{ matrix.ruby-version }}"
+    name: "RSpec / Ruby ${{ matrix.ruby-version }} / Faraday ${{ matrix.faraday }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby-version: ["3.2", "3.1", "3.0", "2.7"]
+        faraday: ["1.0", "2.0"]
+    env:
+      FARADAY_VERSION: ${{ matrix.faraday }}
     steps:
       - uses: actions/checkout@v4
       - run: ./script/install-apt-deps.sh

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,16 @@ gem "cucumber", "~> 9.0"
 gem "curb", "~> 1.0.1"
 gem "em-http-request"
 gem "excon", ">= 0.62.0"
-gem "faraday", "~> 1.0"
+
+if ENV['FARADAY_VERSION'] == '1.0'
+  gem "faraday", "~> 1.0"
+else
+  gem "faraday", "~> 2.0"
+  gem "faraday-typhoeus"
+  gem "faraday-patron", '~> 2.0'
+  gem 'faraday-multipart'
+end
+
 gem "hashdiff", ">= 1.0.0.beta1", "< 2.0.0"
 gem "httpclient"
 gem "json"

--- a/features/configuration/hook_into.feature
+++ b/features/configuration/hook_into.feature
@@ -88,7 +88,14 @@ Feature: hook_into
       require 'excon'
       require 'faraday'
       require 'vcr'
-      <extra_require>
+
+      if '<faraday_adapter>' == 'typhoeus'
+        if Faraday::VERSION > '2.0'
+          require "faraday/typhoeus"
+        else
+          require 'typhoeus/adapters/faraday'
+        end
+      end
 
       VCR.configure { |c| c.ignore_localhost = true }
 
@@ -160,6 +167,6 @@ Feature: hook_into
       | Faraday 2: Hello faraday      |
 
     Examples:
-      | hook_into | faraday_adapter | extra_require                       |
-      | :webmock  | net_http        |                                     |
-      | :webmock  | typhoeus        | require 'typhoeus/adapters/faraday' |
+      | hook_into | faraday_adapter |
+      | :webmock  | net_http        |
+      | :webmock  | typhoeus        |

--- a/features/middleware/faraday.feature
+++ b/features/middleware/faraday.feature
@@ -21,7 +21,14 @@ Feature: Faraday middleware
 
       require 'faraday'
       require 'vcr'
-      <extra_require>
+
+      if '<adapter>' == 'typhoeus'
+        if Faraday::VERSION > '2.0'
+          require "faraday/typhoeus"
+        else
+          require 'typhoeus/adapters/faraday'
+        end
+      end
 
       VCR.configure do |c|
         c.default_cassette_options = { :serialize_with => :syck }
@@ -50,7 +57,6 @@ Feature: Faraday middleware
     And the file "cassettes/example.yml" should contain "Hello foo 1"
 
     Examples:
-      | adapter  | extra_require                       |
-      | net_http |                                     |
-      | typhoeus | require 'typhoeus/adapters/faraday' |
-
+      | adapter  |
+      | net_http |
+      | typhoeus |

--- a/lib/vcr/middleware/faraday.rb
+++ b/lib/vcr/middleware/faraday.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday/multipart'
 require 'vcr/util/version_checker'
 require 'vcr/request_handler'
 

--- a/spec/lib/vcr/middleware/faraday_spec.rb
+++ b/spec/lib/vcr/middleware/faraday_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe VCR::Middleware::Faraday do
 
     def self.test_recording
       it 'records the request body correctly' do
-        payload = { :file => Faraday::UploadIO.new(__FILE__, 'text/plain') }
+        payload = { :file => Faraday::FilePart.new(__FILE__, 'text/plain') }
 
         expect(VCR).to receive(:record_http_interaction) do |i|
           expect(i.request.headers['Content-Type'].first).to include("multipart")

--- a/spec/support/http_library_adapters.rb
+++ b/spec/support/http_library_adapters.rb
@@ -209,8 +209,12 @@ HTTP_LIBRARY_ADAPTERS['excon'] = Module.new do
   end
 end
 
+require 'faraday'
+
 %w[ net_http typhoeus patron ].each do |_faraday_adapter|
-  if _faraday_adapter == 'typhoeus' &&
+  if Faraday::VERSION > '2.0'
+    require "faraday/#{_faraday_adapter}"
+  elsif _faraday_adapter == 'typhoeus' &&
      defined?(::Typhoeus::VERSION) &&
      ::Typhoeus::VERSION.to_f >= 0.5
     require 'typhoeus/adapters/faraday'


### PR DESCRIPTION
Hi, 

I took a stab into making specs run against faraday 1 and 2. In the past, this repo was using https://github.com/thoughtbot/appraisal for stuff like this, It's also an option.

But If we want only to test against faraday 2, I can rework this PR and remove the faraday 1.x stuff. 

I was also thinking about having the same strategy to support newer rack versions, while keeping compatibility 🤔  What do you think? 

This closes #1001