### PR TITLE
Add Rack 2 and Rack 3 to the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,16 @@ on:
 
 jobs:
   cucumber:
-    name: "Cucumber / Ruby ${{ matrix.ruby-version }} / Faraday ${{ matrix.faraday }}"
+    name: "Cucumber / Ruby ${{ matrix.ruby-version }} / Rack ${{ matrix.rack }} / Faraday ${{ matrix.faraday }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.2", "3.1", "3.0", "2.7"]
+        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7"]
         faraday: ["1.0", "2.0"]
+        rack: ["2.0", "3.0"]
     env:
       FARADAY_VERSION: ${{ matrix.faraday }}
+      RACK_VERSION: ${{ matrix.rack }}
     steps:
       - uses: actions/checkout@v4
       - run: ./script/install-apt-deps.sh
@@ -26,14 +28,16 @@ jobs:
       - name: cucumber
         run: ./script/fail_if_warnings cucumber features/
   rspec:
-    name: "RSpec / Ruby ${{ matrix.ruby-version }} / Faraday ${{ matrix.faraday }}"
+    name: "RSpec / Ruby ${{ matrix.ruby-version }} / Rack ${{ matrix.rack }} / Faraday ${{ matrix.faraday }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.2", "3.1", "3.0", "2.7"]
+        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7"]
         faraday: ["1.0", "2.0"]
+        rack: ["2.0", "3.0"]
     env:
       FARADAY_VERSION: ${{ matrix.faraday }}
+      RACK_VERSION: ${{ matrix.rack }}
     steps:
       - uses: actions/checkout@v4
       - run: ./script/install-apt-deps.sh

--- a/Gemfile
+++ b/Gemfile
@@ -13,13 +13,13 @@ gem "curb", "~> 1.0.1"
 gem "em-http-request"
 gem "excon", ">= 0.62.0"
 
-if ENV['FARADAY_VERSION'] == '1.0'
+if ENV['FARADAY_VERSION'] == "1.0"
   gem "faraday", "~> 1.0"
 else
   gem "faraday", "~> 2.0"
   gem "faraday-typhoeus"
-  gem "faraday-patron", '~> 2.0'
-  gem 'faraday-multipart'
+  gem "faraday-patron", "~> 2.0"
+  gem "faraday-multipart"
 end
 
 gem "hashdiff", ">= 1.0.0.beta1", "< 2.0.0"
@@ -30,7 +30,14 @@ gem "mutex_m"
 gem "patron", "0.6.3"
 gem "pry-doc", "~> 0.6"
 gem "pry", "~> 0.9"
-gem "rack", "< 3" # LOCKED: in order to pass tests that rely on Rack::Handlers::WEBRickHandler
+
+if ENV["RACK_VERSION"] == "2.0"
+  gem "rack", "< 3"
+else
+  gem "rack", "~> 3.0"
+  gem "rackup"
+end
+
 gem "rake", ">= 12.3.3"
 gem "rspec", "~> 3.0"
 gem "sinatra"

--- a/spec/support/vcr_localhost_server.rb
+++ b/spec/support/vcr_localhost_server.rb
@@ -1,5 +1,5 @@
 require 'rack'
-require 'rackup'
+require 'rackup' if Rack.release > '3.0'
 require 'net/http'
 require 'webrick'
 
@@ -45,7 +45,12 @@ module VCR
       # Use WEBrick since it's part of the ruby standard library and is available on all ruby interpreters.
       options = { :Port => port, :ShutdownSocketWithoutClose => true }
       options.merge!(:AccessLog => [], :Logger => WEBrick::BasicLog.new(StringIO.new)) unless ENV['VERBOSE_SERVER']
-      Rackup::Handler::WEBrick.run(Identify.new(@rack_app), **options)
+
+      if defined?(Rackup)
+        Rackup::Handler::WEBrick.run(Identify.new(@rack_app), **options)
+      else
+        Rack::Handler::WEBrick.run(Identify.new(@rack_app), **options)
+      end
     end
 
     def booted?

--- a/spec/support/vcr_localhost_server.rb
+++ b/spec/support/vcr_localhost_server.rb
@@ -1,4 +1,5 @@
 require 'rack'
+require 'rackup'
 require 'net/http'
 require 'webrick'
 
@@ -44,7 +45,7 @@ module VCR
       # Use WEBrick since it's part of the ruby standard library and is available on all ruby interpreters.
       options = { :Port => port, :ShutdownSocketWithoutClose => true }
       options.merge!(:AccessLog => [], :Logger => WEBrick::BasicLog.new(StringIO.new)) unless ENV['VERBOSE_SERVER']
-      Rack::Handler::WEBrick.run(Identify.new(@rack_app), **options)
+      Rackup::Handler::WEBrick.run(Identify.new(@rack_app), **options)
     end
 
     def booted?

--- a/spec/support/vcr_localhost_server.rb
+++ b/spec/support/vcr_localhost_server.rb
@@ -1,6 +1,6 @@
 require 'rack'
-require 'rack/handler/webrick'
 require 'net/http'
+require 'webrick'
 
 # The code for this is inspired by Capybara's server:
 #   http://github.com/jnicklas/capybara/blob/0.3.9/lib/capybara/server.rb


### PR DESCRIPTION
Same approach as #1024, but now adding Rack 2 and Rack 3 to Github Actions. Huge combination of executions now, but I think it's better to run against those combinations while most projects are still upgrading between faraday/rack.

I also got some commits from #1010 to add Ruby 3.3 too 🙌  hope that's ok. We may also add ruby-head later too? 

Closes #1020