### PR TITLE
add error message when cassete file does not exist

### DIFF
--- a/lib/vcr/errors.rb
+++ b/lib/vcr/errors.rb
@@ -212,6 +212,14 @@ module VCR
           "https://benoittgt.github.io/vcr/?v=%s#/record_modes/none"
         ],
 
+        :none_without_file => [
+          ["The current record mode (:none) does not allow requests to be recorded.",
+           "One or more cassette names registered was not found. Use ",
+           ":new_episodes or :once record modes to record a new cassette"],
+          "https://benoittgt.github.io/vcr/?v=%s#/record_modes/none"
+        ],
+          
+
         :use_a_cassette => [
           ["If you want VCR to record this request and play it back during future test",
            "runs, you should wrap your test (or this portion of your test) in a",
@@ -284,11 +292,19 @@ module VCR
         record_modes = current_cassettes.map(&:record_mode)
 
         if record_modes.all?{|r| r == :none }
-          [:deal_with_none]
+          none_suggestion
         elsif record_modes.all?{|r| r == :once }
           [:delete_cassette_for_once]
         else
           []
+        end
+      end
+
+      def none_suggestion
+        if current_cassettes.any? {|c| !File.exist?(c.file) }
+          [:none_without_file]
+        else
+          [:deal_with_none]
         end
       end
 

--- a/spec/lib/vcr/errors_spec.rb
+++ b/spec/lib/vcr/errors_spec.rb
@@ -126,6 +126,15 @@ module VCR
           end
         end
 
+        it 'mentions legacy message when file exists' do
+          VCR.configure do |c|
+            c.cassette_library_dir = File.join(VCR::SPEC_ROOT, 'fixtures')
+          end
+          VCR.use_cassette('fake_example_responses', :record => :none) do
+            expect(message).to include('can temporarily change the record mode to :once, delete the cassette file')
+          end
+        end
+
         it 'does not mention the :once or :none record modes if using the :new_episodes record mode' do
           VCR.use_cassette('example', :record => :new_episodes) do
             expect(message).not_to include(':once', ':none')

--- a/spec/lib/vcr/errors_spec.rb
+++ b/spec/lib/vcr/errors_spec.rb
@@ -120,6 +120,12 @@ module VCR
           end
         end
 
+        it 'mentions that one of the files does not exist when using :none and file does not exist' do
+          VCR.use_cassette('example', :record => :none) do
+            expect(message).to include('One or more cassette names registered was not found.')
+          end
+        end
+
         it 'does not mention the :once or :none record modes if using the :new_episodes record mode' do
           VCR.use_cassette('example', :record => :new_episodes) do
             expect(message).not_to include(':once', ':none')


### PR DESCRIPTION
Issue: https://github.com/vcr/vcr/issues/985

Adds error message to when cassete is using record mode :none but file is not found