### PR TITLE
CI: Disable fail-fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     name: "Cucumber / Ruby ${{ matrix.ruby-version }} / Rack ${{ matrix.rack }} / Faraday ${{ matrix.faraday }}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7"]
         faraday: ["1.0", "2.0"]
@@ -31,6 +32,7 @@ jobs:
     name: "RSpec / Ruby ${{ matrix.ruby-version }} / Rack ${{ matrix.rack }} / Faraday ${{ matrix.faraday }}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7"]
         faraday: ["1.0", "2.0"]


### PR DESCRIPTION
It was brought to my attention that a test run on `master` failed, where the PR had succeeded.

- Failed: https://github.com/vcr/vcr/actions/runs/10451748955/job/28938776171
- Worked in the PR: https://github.com/vcr/vcr/actions/runs/10451357527/job/28937615586?pr=1029

In order to see more information, and be able to gather data points, this PR disables the fail-fast: true default setting.