### PR TITLE
Move require "faraday/multipart" to spec/ where it is being used

### DIFF
--- a/lib/vcr/middleware/faraday.rb
+++ b/lib/vcr/middleware/faraday.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'faraday/multipart'
 require 'vcr/util/version_checker'
 require 'vcr/request_handler'
 

--- a/spec/lib/vcr/middleware/faraday_spec.rb
+++ b/spec/lib/vcr/middleware/faraday_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'vcr/library_hooks/faraday'
+require 'faraday/multipart'
 
 RSpec.describe VCR::Middleware::Faraday do
   http_libs = %w[ typhoeus net_http patron ]


### PR DESCRIPTION
This PR moves a `require` statement to a test file, out of the implementation file. This makes the library required a test dependency only, avoiding users having to change their Gemfile.

Try to fix #1031