### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/vcr

### DIFF
--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "base64"
+
+  spec.metadata["changelog_uri"] = "https://github.com/vcr/vcr/blob/master/CHANGELOG.md"
 end

--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64"
 
-  spec.metadata["changelog_uri"] = "https://github.com/vcr/vcr/blob/master/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/vcr/vcr/blob/v#{spec.version}/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/vcr which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/