### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/vcr.gemspec
+++ b/vcr.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64"
 
   spec.metadata["changelog_uri"] = "https://github.com/vcr/vcr/blob/v#{spec.version}/CHANGELOG.md"
+  spec.metadata["funding_uri"] = "https://opencollective.com/vcr"
 end


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.