### PR TITLE
Remove unnecessary "".respond_to?(:encoding) checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "codeclimate-test-reporter", "~> 0.4"
 gem "cucumber", "~> 9.0"
 gem "curb", "~> 1.0.1"
 gem "em-http-request"
-gem "excon", ">= 0.62.0"
+gem "excon", ">= 0.62.0", "< 1.0.0"
 
 if ENV['FARADAY_VERSION'] == "1.0"
   gem "faraday", "~> 1.0"

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -25,39 +25,29 @@ module VCR
           end
         end
 
-        if "".respond_to?(:encoding)
-          def force_encode_string(string, encoding)
-            return string unless encoding
-            string.force_encoding(encoding)
-          end
+        def force_encode_string(string, encoding)
+          return string unless encoding
+          string.force_encoding(encoding)
+        end
 
-          def try_encode_string(string, encoding_name)
-            return string if encoding_name.nil?
+        def try_encode_string(string, encoding_name)
+          return string if encoding_name.nil?
 
-            encoding = Encoding.find(encoding_name)
-            return string if string.encoding == encoding
+          encoding = Encoding.find(encoding_name)
+          return string if string.encoding == encoding
 
-            # ASCII-8BIT just means binary, so encoding to it is nonsensical
-            # and yet "\u00f6".encode("ASCII-8BIT") raises an error.
-            # Instead, we'll force encode it (essentially just tagging it as binary)
-            return string.force_encoding(encoding) if encoding == Encoding::BINARY
+          # ASCII-8BIT just means binary, so encoding to it is nonsensical
+          # and yet "\u00f6".encode("ASCII-8BIT") raises an error.
+          # Instead, we'll force encode it (essentially just tagging it as binary)
+          return string.force_encoding(encoding) if encoding == Encoding::BINARY
 
-            string.encode(encoding)
-          rescue EncodingError => e
-            struct_type = name.split('::').last.downcase
-            warn "VCR: got `#{e.class.name}: #{e.message}` while trying to encode the #{string.encoding.name} " +
-                 "#{struct_type} body to the original body encoding (#{encoding}). Consider using the " +
-                 "`:preserve_exact_body_bytes` option to work around this."
-            return string
-          end
-        else
-          def force_encode_string(string, encoding)
-            string
-          end
-
-          def try_encode_string(string, encoding)
-            string
-          end
+          string.encode(encoding)
+        rescue EncodingError => e
+          struct_type = name.split('::').last.downcase
+          warn "VCR: got `#{e.class.name}: #{e.message}` while trying to encode the #{string.encoding.name} " +
+                "#{struct_type} body to the original body encoding (#{encoding}). Consider using the " +
+                "`:preserve_exact_body_bytes` option to work around this."
+          return string
         end
       end
 
@@ -91,14 +81,8 @@ module VCR
         end
       end
 
-      if ''.respond_to?(:encoding)
-        def base_body_hash(body)
-          { 'encoding' => body.encoding.name }
-        end
-      else
-        def base_body_hash(body)
-          { }
-        end
+      def base_body_hash(body)
+        { 'encoding' => body.encoding.name }
       end
     end
 
@@ -417,7 +401,7 @@ module VCR
         when 'gzip'
           body_str = ''
           args = [StringIO.new(body_str)]
-          args << { :encoding => 'ASCII-8BIT' } if ''.respond_to?(:encoding)
+          args << { :encoding => 'ASCII-8BIT' }
           writer = Zlib::GzipWriter.new(*args)
           writer.write(body)
           writer.close
@@ -458,7 +442,7 @@ module VCR
       case type
       when 'gzip'
         gzip_reader_options = {}
-        gzip_reader_options[:encoding] = 'ASCII-8BIT' if ''.respond_to?(:encoding)
+        gzip_reader_options[:encoding] = 'ASCII-8BIT'
         yield Zlib::GzipReader.new(StringIO.new(body),
                                    **gzip_reader_options).read
       when 'deflate'

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -400,9 +400,7 @@ module VCR
         case type
         when 'gzip'
           body_str = ''
-          args = [StringIO.new(body_str)]
-          args << { :encoding => 'ASCII-8BIT' }
-          writer = Zlib::GzipWriter.new(*args)
+          writer = Zlib::GzipWriter.new(StringIO.new(body_str), encoding: 'ASCII-8BIT')
           writer.write(body)
           writer.close
           body_str
@@ -441,10 +439,7 @@ module VCR
 
       case type
       when 'gzip'
-        gzip_reader_options = {}
-        gzip_reader_options[:encoding] = 'ASCII-8BIT'
-        yield Zlib::GzipReader.new(StringIO.new(body),
-                                   **gzip_reader_options).read
+        yield Zlib::GzipReader.new(StringIO.new(body), encoding: 'ASCII-8BIT').read
       when 'deflate'
         yield Zlib::Inflate.inflate(body)
       when 'identity', NilClass

--- a/spec/lib/vcr/cassette/migrator_spec.rb
+++ b/spec/lib/vcr/cassette/migrator_spec.rb
@@ -101,11 +101,6 @@ EOF
     FileUtils.mkdir_p dir
   end
 
-  before(:each) do
-    # the encoding won't be set on rubies that don't support it
-    updated_contents.gsub!(/^\s+encoding:.*$/, '')
-  end unless ''.respond_to?(:encoding)
-
   # JRuby serializes YAML with some slightly different whitespace.
   before(:each) do
     [original_contents, updated_contents].each do |contents|
@@ -191,4 +186,3 @@ EOF
     it_behaves_like "ignoring invalid YAML"
   end if defined?(YAML::ENGINE)
 end
-

--- a/spec/lib/vcr/cassette/serializers_spec.rb
+++ b/spec/lib/vcr/cassette/serializers_spec.rb
@@ -67,7 +67,7 @@ module VCR
         it_behaves_like "encoding error handling", :yaml, ArgumentError do
           let(:string) { "\xFA".force_encoding("UTF-8") }
           before { ::YAML::ENGINE.yamler = 'psych' if defined?(::YAML::ENGINE) }
-        end if ''.respond_to?(:encoding)
+        end
 
         it_behaves_like "syntax error handling", :yaml, ::Psych::SyntaxError do
           let(:serialized) { <<~YAML }
@@ -83,7 +83,7 @@ module VCR
       it_behaves_like "a serializer", :syck,  "yml",  :lazily_loaded do
         it_behaves_like "encoding error handling", :syck, ArgumentError do
           let(:string) { "\xFA".force_encoding("UTF-8") }
-        end if ''.respond_to?(:encoding)
+        end
 
         it_behaves_like "syntax error handling", :syck, ::Psych::SyntaxError do
           let(:serialized) { <<~YAML }
@@ -98,7 +98,7 @@ module VCR
       it_behaves_like "a serializer", :psych, "yml",  :lazily_loaded do
         it_behaves_like "encoding error handling", :psych, ArgumentError do
           let(:string) { "\xFA".force_encoding("UTF-8") }
-        end if ''.respond_to?(:encoding)
+        end
 
         it_behaves_like "syntax error handling", :psych, ::Psych::SyntaxError do
           let(:serialized) { <<~YAML }
@@ -113,7 +113,7 @@ module VCR
       it_behaves_like "a serializer", :compressed, "zz",  :lazily_loaded do
         it_behaves_like "encoding error handling", :compressed, ArgumentError do
           let(:string) { "\xFA".force_encoding("UTF-8") }
-        end if ''.respond_to?(:encoding)
+        end
 
         it_behaves_like "syntax error handling", :compressed, ::Psych::SyntaxError do
           let(:serialized) { Zlib::Deflate.deflate(<<~YAML) }

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -65,14 +65,8 @@ module VCR
     include_context "configuration stubbing"
     before { allow(config).to receive(:uri_parser) { LimitedURI } }
 
-    if ''.respond_to?(:encoding)
-      def body_hash(key, value)
-        { key => value, 'encoding' => 'UTF-8' }
-      end
-    else
-      def body_hash(key, value)
-        { key => value }
-      end
+    def body_hash(key, value)
+      { key => value, 'encoding' => 'UTF-8' }
     end
 
     describe "#recorded_at" do
@@ -164,95 +158,93 @@ module VCR
         expect(i.response.body).to eq('res body')
       end
 
-      if ''.respond_to?(:encoding)
-        it 'force encodes the decoded base64 string as the original encoding' do
-          string = "café"
-          string.force_encoding("US-ASCII")
-          expect(string).not_to be_valid_encoding
+      it 'force encodes the decoded base64 string as the original encoding' do
+        string = "café"
+        string.force_encoding("US-ASCII")
+        expect(string).not_to be_valid_encoding
 
-          hash['request']['body']  = { 'base64_string' => Base64.encode64(string.dup), 'encoding' => 'US-ASCII' }
-          hash['response']['body'] = { 'base64_string' => Base64.encode64(string.dup), 'encoding' => 'US-ASCII' }
+        hash['request']['body']  = { 'base64_string' => Base64.encode64(string.dup), 'encoding' => 'US-ASCII' }
+        hash['response']['body'] = { 'base64_string' => Base64.encode64(string.dup), 'encoding' => 'US-ASCII' }
 
-          i = HTTPInteraction.from_hash(hash)
-          expect(i.request.body.encoding.name).to eq("US-ASCII")
-          expect(i.response.body.encoding.name).to eq("US-ASCII")
-          expect(i.request.body.bytes.to_a).to eq(string.bytes.to_a)
-          expect(i.response.body.bytes.to_a).to eq(string.bytes.to_a)
-          expect(i.request.body).not_to be_valid_encoding
-          expect(i.response.body).not_to be_valid_encoding
+        i = HTTPInteraction.from_hash(hash)
+        expect(i.request.body.encoding.name).to eq("US-ASCII")
+        expect(i.response.body.encoding.name).to eq("US-ASCII")
+        expect(i.request.body.bytes.to_a).to eq(string.bytes.to_a)
+        expect(i.response.body.bytes.to_a).to eq(string.bytes.to_a)
+        expect(i.request.body).not_to be_valid_encoding
+        expect(i.response.body).not_to be_valid_encoding
+      end
+
+      it 'does not attempt to force encode the decoded base64 string when there is no encoding given (i.e. if the cassette was recorded on ruby 1.8)' do
+        hash['request']['body']  = { 'base64_string' => Base64.encode64('foo') }
+
+        i = HTTPInteraction.from_hash(hash)
+        expect(i.request.body).to eq('foo')
+        expect(i.request.body.encoding).to eq(Encoding::BINARY)
+      end
+
+      it 'tries to encode strings to the original encoding' do
+        hash['request']['body']  = { 'string' => "abc", 'encoding' => 'ISO-8859-1' }
+        hash['response']['body'] = { 'string' => "abc", 'encoding' => 'ISO-8859-1' }
+
+        i = HTTPInteraction.from_hash(hash)
+        expect(i.request.body).to eq("abc")
+        expect(i.response.body).to eq("abc")
+        expect(i.request.body.encoding.name).to eq("ISO-8859-1")
+        expect(i.response.body.encoding.name).to eq("ISO-8859-1")
+      end
+
+      it 'does not attempt to encode the string when there is no encoding given (i.e. if the cassette was recorded on ruby 1.8)' do
+        string = 'foo'
+        string.force_encoding("ISO-8859-1")
+        hash['request']['body']  = { 'string' => string }
+
+        i = HTTPInteraction.from_hash(hash)
+        expect(i.request.body).to eq('foo')
+        expect(i.request.body.encoding.name).to eq("ISO-8859-1")
+      end
+
+      it 'force encodes to ASCII-8BIT (since it just means "no encoding" or binary)' do
+        string = "\u00f6"
+        string.encode("UTF-8")
+        expect(string).to be_valid_encoding
+        hash['request']['body']  = { 'string' => string, 'encoding' => 'ASCII-8BIT' }
+
+        expect(Request).not_to receive(:warn)
+        i = HTTPInteraction.from_hash(hash)
+        expect(i.request.body).to eq(string)
+        expect(i.request.body.bytes.to_a).to eq(string.bytes.to_a)
+        expect(i.request.body.encoding).to eq(Encoding::BINARY)
+      end
+
+      context 'when the string cannot be encoded as the original encoding' do
+        def verify_encoding_error
+          expect { "\xFAbc".encode("ISO-8859-1") }.to raise_error(EncodingError)
         end
 
-        it 'does not attempt to force encode the decoded base64 string when there is no encoding given (i.e. if the cassette was recorded on ruby 1.8)' do
-          hash['request']['body']  = { 'base64_string' => Base64.encode64('foo') }
+        before do
+          allow(Request).to receive(:warn)
+          allow(Response).to receive(:warn)
 
-          i = HTTPInteraction.from_hash(hash)
-          expect(i.request.body).to eq('foo')
-          expect(i.request.body.encoding).to eq(Encoding::BINARY)
+          hash['request']['body']  = { 'string' => "\xFAbc", 'encoding' => 'ISO-8859-1' }
+          hash['response']['body']  = { 'string' => "\xFAbc", 'encoding' => 'ISO-8859-1' }
+
+          verify_encoding_error
         end
 
-        it 'tries to encode strings to the original encoding' do
-          hash['request']['body']  = { 'string' => "abc", 'encoding' => 'ISO-8859-1' }
-          hash['response']['body'] = { 'string' => "abc", 'encoding' => 'ISO-8859-1' }
-
+        it 'does not force the encoding' do
           i = HTTPInteraction.from_hash(hash)
-          expect(i.request.body).to eq("abc")
-          expect(i.response.body).to eq("abc")
-          expect(i.request.body.encoding.name).to eq("ISO-8859-1")
-          expect(i.response.body.encoding.name).to eq("ISO-8859-1")
+          expect(i.request.body).to eq("\xFAbc")
+          expect(i.response.body).to eq("\xFAbc")
+          expect(i.request.body.encoding.name).not_to eq("ISO-8859-1")
+          expect(i.response.body.encoding.name).not_to eq("ISO-8859-1")
         end
 
-        it 'does not attempt to encode the string when there is no encoding given (i.e. if the cassette was recorded on ruby 1.8)' do
-          string = 'foo'
-          string.force_encoding("ISO-8859-1")
-          hash['request']['body']  = { 'string' => string }
+        it 'prints a warning and informs users of the :preserve_exact_body_bytes option' do
+          expect(Request).to receive(:warn).with(/ISO-8859-1.*preserve_exact_body_bytes/)
+          expect(Response).to receive(:warn).with(/ISO-8859-1.*preserve_exact_body_bytes/)
 
-          i = HTTPInteraction.from_hash(hash)
-          expect(i.request.body).to eq('foo')
-          expect(i.request.body.encoding.name).to eq("ISO-8859-1")
-        end
-
-        it 'force encodes to ASCII-8BIT (since it just means "no encoding" or binary)' do
-          string = "\u00f6"
-          string.encode("UTF-8")
-          expect(string).to be_valid_encoding
-          hash['request']['body']  = { 'string' => string, 'encoding' => 'ASCII-8BIT' }
-
-          expect(Request).not_to receive(:warn)
-          i = HTTPInteraction.from_hash(hash)
-          expect(i.request.body).to eq(string)
-          expect(i.request.body.bytes.to_a).to eq(string.bytes.to_a)
-          expect(i.request.body.encoding).to eq(Encoding::BINARY)
-        end
-
-        context 'when the string cannot be encoded as the original encoding' do
-          def verify_encoding_error
-            expect { "\xFAbc".encode("ISO-8859-1") }.to raise_error(EncodingError)
-          end
-
-          before do
-            allow(Request).to receive(:warn)
-            allow(Response).to receive(:warn)
-
-            hash['request']['body']  = { 'string' => "\xFAbc", 'encoding' => 'ISO-8859-1' }
-            hash['response']['body']  = { 'string' => "\xFAbc", 'encoding' => 'ISO-8859-1' }
-
-            verify_encoding_error
-          end
-
-          it 'does not force the encoding' do
-            i = HTTPInteraction.from_hash(hash)
-            expect(i.request.body).to eq("\xFAbc")
-            expect(i.response.body).to eq("\xFAbc")
-            expect(i.request.body.encoding.name).not_to eq("ISO-8859-1")
-            expect(i.response.body.encoding.name).not_to eq("ISO-8859-1")
-          end
-
-          it 'prints a warning and informs users of the :preserve_exact_body_bytes option' do
-            expect(Request).to receive(:warn).with(/ISO-8859-1.*preserve_exact_body_bytes/)
-            expect(Response).to receive(:warn).with(/ISO-8859-1.*preserve_exact_body_bytes/)
-
-            HTTPInteraction.from_hash(hash)
-          end
+          HTTPInteraction.from_hash(hash)
         end
       end
     end
@@ -316,7 +308,7 @@ module VCR
         expect(hash['response']['body']).to eq(body_hash('base64_string', Base64.encode64('res body')))
       end
 
-      it "sets the string's original encoding", :if => ''.respond_to?(:encoding) do
+      it "sets the string's original encoding" do
         interaction.request.body.force_encoding('ISO-8859-10')
         interaction.response.body.force_encoding(Encoding::BINARY)
 
@@ -744,4 +736,3 @@ module VCR
     end
   end
 end
-


### PR DESCRIPTION
These checks were added back when String didn't have encoding. 

As VCR supports Ruby 2.7+ now, I don't think they are necessary anymore.

I've also pinned excon to < 1.0.0, It seems some webmock specs are failing with excon >= 1.0.0 which was recently released.  
