### PR TITLE
Do not raise an exception if the body is missing from the response

### DIFF
--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -31,7 +31,7 @@ module VCR
         end
 
         def try_encode_string(string, encoding_name)
-          return string if encoding_name.nil?
+          return string if encoding_name.nil? || string.nil?
 
           encoding = Encoding.find(encoding_name)
           return string if string.encoding == encoding

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -149,6 +149,13 @@ module VCR
         expect(i.response).to eq(Response.new(ResponseStatus.new))
       end
 
+      it 'uses a blank body if it is missing from the response' do
+        hash['response']['body'] = { 'encoding' => 'US-ASCII' }
+
+        i = HTTPInteraction.from_hash(hash)
+        expect(i.response.body).to eq('')
+      end
+
       it 'decodes the base64 body string' do
         hash['request']['body'] = body_hash('base64_string', Base64.encode64('req body'))
         hash['response']['body'] = body_hash('base64_string', Base64.encode64('res body'))


### PR DESCRIPTION
If somehow a cassette does not have a string body, VCR shouldn't raise an error.

```ruby 
MethodError (undefined method 'encoding' for nil):

lib/vcr/structs.rb:38:in 'VCR::Normalizers::Body::ClassMethods#try_encode_string'
lib/vcr/structs.rb:24:in 'VCR::Normalizers::Body::ClassMethods#body_from'
lib/vcr/structs.rb:366:in 'VCR::Response.from_hash'
lib/vcr/structs.rb:529:in 'VCR::HTTPInteraction.from_hash'
lib/vcr/cassette.rb:215:in 'block in VCR::Cassette#previously_recorded_interactions'
lib/vcr/cassette.rb:215:in 'Array#map'
lib/vcr/cassette.rb:215:in 'VCR::Cassette#previously_recorded_interactions'
lib/vcr/cassette.rb:107:in 'block in VCR::Cassette#http_interactions'
lib/vcr/cassette.rb:105:in 'Thread::Mutex#synchronize'
lib/vcr/cassette.rb:105:in 'VCR::Cassette#http_interactions'
lib/vcr.rb:346:in 'VCR#http_interactions'
lib/vcr/request_handler.rb:75:in 'VCR::RequestHandler#stubbed_response'
lib/vcr/request_handler.rb:68:in 'VCR::RequestHandler#has_response_stub?'
lib/vcr/request_handler.rb:37:in 'VCR::RequestHandler#request_type'
lib/vcr/request_handler.rb:10:in 'VCR::RequestHandler#handle'
lib/vcr/middleware/faraday.rb:53:in 'VCR::Middleware::Faraday::RequestHandler#handle'
lib/vcr/middleware/faraday.rb:31:in 'VCR::Middleware::Faraday#call'
```

I didn't understand how the invalid cassette was generated on that issue. That might need a different fix. But anyway, this is nice to have fixed.

Fixes #1042 

~~P.S: Webmock excon specs are failing with excon >= 1.0.0. I fixed it on #1043~~ Merged!