### PR TITLE
Add optional description parameter when registring a (custom) matcher

### DIFF
--- a/lib/vcr/configuration.rb
+++ b/lib/vcr/configuration.rb
@@ -180,7 +180,7 @@ module VCR
     #
     # @example
     #  VCR.configure do |c|
-    #    c.register_request_matcher :port do |request_1, request_2|
+    #    c.register_request_matcher :port, ->(request) { "Port: #{URI(request.uri).port}" } do |request_1, request_2|
     #      URI(request_1.uri).port == URI(request_2.uri).port
     #    end
     #  end
@@ -190,13 +190,14 @@ module VCR
     #  end
     #
     # @param name [Symbol] the name of the request matcher
+    # @param description [Proc<VCR::Request>] an optional description to add to the error message for an unhandled request
     # @yield the request matcher
     # @yieldparam request_1 [VCR::Request] One request
     # @yieldparam request_2 [VCR::Request] The other request
     # @yieldreturn [Boolean] whether or not these two requests should be considered
     #  equivalent
-    def register_request_matcher(name, &block)
-      VCR.request_matchers.register(name, &block)
+    def register_request_matcher(name, description = nil, &block)
+      VCR.request_matchers.register(name, description, &block)
     end
 
     # Sets up a {#before_record} and a {#before_playback} hook that will

--- a/lib/vcr/errors.rb
+++ b/lib/vcr/errors.rb
@@ -96,12 +96,10 @@ module VCR
 
         lines << "  #{request.method.to_s.upcase} #{request.uri}"
 
-        if match_request_on_headers?
-          lines << "  Headers:\n#{formatted_headers}"
-        end
+        current_matchers.each do |matcher|
+          next unless description = VCR.request_matchers[matcher].description
 
-        if match_request_on_body?
-          lines << "  Body: #{request.body}"
+          lines << "  #{description.call(request)}"
         end
 
         lines.join("\n")
@@ -123,14 +121,6 @@ module VCR
         else
           VCR.configuration.default_cassette_options[:match_requests_on]
         end
-      end
-
-      def formatted_headers
-        request.headers.flat_map do |header, values|
-          values.map do |val|
-            "    #{header}: #{val.inspect}"
-          end
-        end.join("\n")
       end
 
       def cassettes_description

--- a/spec/lib/vcr/errors_spec.rb
+++ b/spec/lib/vcr/errors_spec.rb
@@ -37,6 +37,17 @@ module VCR
           )
         end
 
+        context 'when the default_cassette_options include a custom matcher with a description' do
+          it 'identifies the request by its headers when the default_cassette_options include the headers in the match_requests_on option' do
+            VCR.configuration.register_request_matcher(:custom, -> (request) { "Custom: #{request.method.to_s.chars.sort.join("")}" }) {}
+            VCR.configuration.default_cassette_options[:match_requests_on] = [:custom]
+
+            expect(message_for(:method => :post)).to include(
+              'Custom: opst'
+            )
+          end
+        end
+
         it 'mentions that there is no cassette' do
           expect(message).to include('There is currently no cassette in use.')
         end

--- a/spec/lib/vcr/request_matcher_registry_spec.rb
+++ b/spec/lib/vcr/request_matcher_registry_spec.rb
@@ -54,7 +54,7 @@ module VCR
       it 'returns a previously registered matcher' do
         matcher = lambda { }
         subject.register(:my_matcher, &matcher)
-        expect(subject[:my_matcher]).to eq(RequestMatcherRegistry::Matcher.new(matcher))
+        expect(subject[:my_matcher]).to eq(RequestMatcherRegistry::Matcher.new(matcher, nil))
       end
 
       it 'raises an ArgumentError when no matcher has been registered for the given name' do


### PR DESCRIPTION
This is so that custom matchers may affect the error message for an unhandled HTTP request the same way the built-in `:headers` and `:body` matchers do.

The logic for these two built-in matchers was refactored to use the new `description` parameter.

Fixes #912
