### PR TITLE
Refresh Ruby support matrix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,16 @@ VCR follows the principles of [semantic versioning](https://semver.org/). The [A
 
 VCR versions 6.x are tested on the following ruby interpreters:
 
+  * MRI 3.3
+  * MRI 3.2
   * MRI 3.1
   * MRI 3.0
   * MRI 2.7
   * MRI 2.6
 
-[VCR 6.0.0](https://github.com/vcr/vcr/releases/tag/v6.0.0) is the last version supporting >= 2.4. Upcoming releases will only explicitly support >= 2.6.
+[VCR 6.0.0](https://github.com/vcr/vcr/releases/tag/v6.0.0) is the last version supporting >= 2.3.
+[VCR 6.1.0](https://github.com/vcr/vcr/releases/tag/v6.1.0) is the last version supporting >= 2.6.
+Upcoming releases will only explicitly support >= 2.7.
 
 **Development**
 


### PR DESCRIPTION
- Adds MRI 3.3 and 3.2 to the list of tested versions
- Updates VCR version compatibility notes:
  - VCR 6.0.0 now reflects support for Ruby >= 2.3 (was >= 2.4)
  - VCR 6.1.0 is noted as the last version for Ruby >= 2.6
  - Future VCR releases will target Ruby >= 2.7

[ci skip]