### PR TITLE
Gemfile: Add irb, rdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,6 @@ gem "typhoeus", ">= 1.1.0"
 gem "webmock"
 gem "webrick"
 gem "yard"
+
+gem "irb" if RUBY_VERSION > "4"
+gem "rdoc" if RUBY_VERSION > "4"


### PR DESCRIPTION
This only affected the "Doc coverage" CI job.

	warning: rdoc used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
	warning: irb/notifier is found in irb, which is not part of the default gems since Ruby 4.0.0.