### PR TITLE
Fix frozen string literal warning when recompressing response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 
 - [fix] Fix recompressing response to happen after replacing sensitive data (#951) by @cgunther
+- [fix] Fix frozen string literal warning when recompressing response (#1073) by @cgunther
 
 ## 6.4.0 (Dec 11, 2025)
 [Full Changelog](https://github.com/vcr/vcr/compare/v6.3.1...v6.4.0)

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -399,7 +399,7 @@ module VCR
       new_body = begin
         case type
         when 'gzip'
-          body_str = ''
+          body_str = String.new
           writer = Zlib::GzipWriter.new(StringIO.new(body_str), encoding: 'ASCII-8BIT')
           writer.write(body)
           writer.close


### PR DESCRIPTION
Without this, the following warning is output:
```
lib/vcr/structs.rb:404: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

Follow up to #832.