### PR TITLE
Support ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7"]
+        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
         faraday: ["1.0", "2.0"]
         rack: ["2.0", "3.0"]
     env:
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7"]
+        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
         faraday: ["1.0", "2.0"]
         rack: ["2.0", "3.0"]
     env:

--- a/Gemfile
+++ b/Gemfile
@@ -49,5 +49,6 @@ gem "webmock"
 gem "webrick"
 gem "yard"
 
+gem "ostruct" if RUBY_VERSION >= "3.4"
 gem "irb" if RUBY_VERSION > "4"
 gem "rdoc" if RUBY_VERSION > "4"

--- a/lib/vcr/cassette.rb
+++ b/lib/vcr/cassette.rb
@@ -64,7 +64,7 @@ module VCR
       extract_options
       raise_error_unless_valid_record_mode
 
-      log "Initialized with options: #{@options.inspect}"
+      log "Initialized with options: #{format_options_for_log(@options)}"
     end
 
     # Ejects the current cassette. The cassette will no longer be used.
@@ -344,6 +344,16 @@ module VCR
 
     def log_prefix
       @log_prefix ||= "[Cassette: '#{name}'] "
+    end
+
+    # Use the legacy `{:key=>val}` format (Ruby 3.4 changed Hash#inspect for symbol keys).
+    def format_options_for_log(value)
+      case value
+      when Hash
+        "{#{value.map { |k, v| "#{k.inspect}=>#{format_options_for_log(v)}" }.join(', ')}}"
+      else
+        value.inspect
+      end
     end
 
     def request_summary(request)

--- a/lib/vcr/cassette/migrator.rb
+++ b/lib/vcr/cassette/migrator.rb
@@ -102,7 +102,7 @@ module VCR
       end
 
       EMPTY_STRING = if String.method_defined?(:force_encoding)
-        ''.force_encoding("US-ASCII")
+        String.new.force_encoding("US-ASCII")
       else
         ''
       end

--- a/lib/vcr/structs.rb
+++ b/lib/vcr/structs.rb
@@ -38,7 +38,7 @@ module VCR
           # ASCII-8BIT just means binary, so encoding to it is nonsensical
           # and yet "\u00f6".encode("ASCII-8BIT") raises an error.
           # Instead, we'll force encode it (essentially just tagging it as binary)
-          return string.force_encoding(encoding) if encoding == Encoding::BINARY
+          return string.dup.force_encoding(encoding) if encoding == Encoding::BINARY
 
           string.encode(encoding)
         rescue EncodingError => e
@@ -545,10 +545,22 @@ module VCR
       def filter!(text, replacement_text)
         text, replacement_text = text.to_s, replacement_text.to_s
         return self if [text, replacement_text].any? { |t| t.empty? }
+        ensure_mutable_strings!(self)
         filter_object!(self, text, replacement_text)
       end
 
     private
+
+      # Walk the interaction and replace any String values with a dup'd copy
+      # so that subsequent in-place mutations (e.g. gsub!) don't trigger
+      # "literal string will be frozen" warnings on Ruby 3.4+.
+      def ensure_mutable_strings!(object)
+        if object.respond_to?(:each_pair) && object.respond_to?(:[]=)
+          object.each_pair { |name, v| v.is_a?(String) ? object[name] = v.dup : ensure_mutable_strings!(v) }
+        elsif object.is_a?(Array)
+          object.each_with_index { |o, i| o.is_a?(String) ? object[i] = o.dup : ensure_mutable_strings!(o) }
+        end
+      end
 
       def filter_object!(object, text, replacement_text)
         if object.respond_to?(:gsub)

--- a/spec/lib/vcr/cassette/serializers_spec.rb
+++ b/spec/lib/vcr/cassette/serializers_spec.rb
@@ -65,7 +65,7 @@ module VCR
 
       it_behaves_like "a serializer", :yaml,  "yml",  :lazily_loaded do
         it_behaves_like "encoding error handling", :yaml, ArgumentError do
-          let(:string) { "\xFA".force_encoding("UTF-8") }
+          let(:string) { "\xFA".dup.force_encoding("UTF-8") }
           before { ::YAML::ENGINE.yamler = 'psych' if defined?(::YAML::ENGINE) }
         end
 
@@ -82,7 +82,7 @@ module VCR
 
       it_behaves_like "a serializer", :syck,  "yml",  :lazily_loaded do
         it_behaves_like "encoding error handling", :syck, ArgumentError do
-          let(:string) { "\xFA".force_encoding("UTF-8") }
+          let(:string) { "\xFA".dup.force_encoding("UTF-8") }
         end
 
         it_behaves_like "syntax error handling", :syck, ::Psych::SyntaxError do
@@ -97,7 +97,7 @@ module VCR
 
       it_behaves_like "a serializer", :psych, "yml",  :lazily_loaded do
         it_behaves_like "encoding error handling", :psych, ArgumentError do
-          let(:string) { "\xFA".force_encoding("UTF-8") }
+          let(:string) { "\xFA".dup.force_encoding("UTF-8") }
         end
 
         it_behaves_like "syntax error handling", :psych, ::Psych::SyntaxError do
@@ -112,7 +112,7 @@ module VCR
 
       it_behaves_like "a serializer", :compressed, "zz",  :lazily_loaded do
         it_behaves_like "encoding error handling", :compressed, ArgumentError do
-          let(:string) { "\xFA".force_encoding("UTF-8") }
+          let(:string) { "\xFA".dup.force_encoding("UTF-8") }
         end
 
         it_behaves_like "syntax error handling", :compressed, ::Psych::SyntaxError do

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -220,7 +220,7 @@ module VCR
 
         expect(Request).not_to receive(:warn)
         i = HTTPInteraction.from_hash(hash)
-        expect(i.request.body).to eq(string)
+        expect(i.request.body).to eq(string.dup.force_encoding(Encoding::BINARY))
         expect(i.request.body.bytes.to_a).to eq(string.bytes.to_a)
         expect(i.request.body.encoding).to eq(Encoding::BINARY)
       end

--- a/spec/lib/vcr/structs_spec.rb
+++ b/spec/lib/vcr/structs_spec.rb
@@ -17,14 +17,14 @@ RSpec.shared_examples_for "a header normalizer" do
   end
 
   it 'ensures header keys are serialized to yaml as raw strings' do
-    key = 'my-key'
+    key = 'my-key'.dup
     key.instance_variable_set(:@foo, 7)
     instance = with_headers(key => ['value1'])
     expect(YAML.dump(instance.headers)).to eq(YAML.dump('my-key' => ['value1']))
   end
 
   it 'ensures header values are serialized to yaml as raw strings' do
-    value = 'my-value'
+    value = 'my-value'.dup
     value.instance_variable_set(:@foo, 7)
     instance = with_headers('my-key' => [value])
     expect(YAML.dump(instance.headers)).to eq(YAML.dump('my-key' => ['my-value']))
@@ -45,7 +45,7 @@ end
 
 RSpec.shared_examples_for "a body normalizer" do
   it "ensures the body is serialized to yaml as a raw string" do
-    body = "My String"
+    body = "My String".dup
     body.instance_variable_set(:@foo, 7)
     expect(YAML.dump(instance(body).body)).to eq(YAML.dump("My String"))
   end
@@ -167,7 +167,7 @@ module VCR
       end
 
       it 'force encodes the decoded base64 string as the original encoding' do
-        string = "café"
+        string = "café".dup
         string.force_encoding("US-ASCII")
         expect(string).not_to be_valid_encoding
 
@@ -203,7 +203,7 @@ module VCR
       end
 
       it 'does not attempt to encode the string when there is no encoding given (i.e. if the cassette was recorded on ruby 1.8)' do
-        string = 'foo'
+        string = 'foo'.dup
         string.force_encoding("ISO-8859-1")
         hash['request']['body']  = { 'string' => string }
 


### PR DESCRIPTION
Add Ruby 3.4 to the CI test matrix and fix the issues that surfaced.

- Add `ostruct` to the Gemfile — Ruby 3.4 emits a warning that it will no longer be a default gem from Ruby 4.0.0:
  warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.0.0.
- Silence `literal string will be frozen` warnings around `force_encoding` and `gsub!` (chilled literals on Ruby 3.4+).
- Format cassette options with the legacy `{:key=>val}` style so debug log output stays consistent (Ruby 3.4 changed `Hash#inspect` for symbol keys).